### PR TITLE
Fix OpenMC CI issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
         shell: bash
         run: |
           pip install -U pip
-          pushd /opt/openmc
-          pip install -e .
+          pushd /root/OpenMC/openmc
+          pip install .[test]
           popd
           pip install .[test]
 


### PR DESCRIPTION
OpenMC just had a new release the other day (version 0.13.0). The location of the install in the Dockerfile was changed, so this PR just updates our ci.yml file so that the OpenMC Python API is installed correctly.