### PR TITLE
Add GH action for publishing to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.1.0]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ questions, please contact [watts@anl.gov](mailto:watts@anl.gov).
 
 ## Installation
 
-- git clone https://github.com/watts-dev/watts
-- cd watts
-- pip install -U pip
-- pip install .
+- pip install watts
 
 ## Documentation
 

--- a/doc/source/_static/switcher.json
+++ b/doc/source/_static/switcher.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "dev",
+        "version": "latest"
+    },
+    {
+        "name": "0.1.0",
+        "version": "v0.1.0"
+    }
+]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -52,6 +52,9 @@ intersphinx_mapping = {
     'astropy': ('https://docs.astropy.org/en/stable/', None)
 }
 
+import watts
+version = release = watts.__version__
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -65,16 +68,15 @@ except ImportError as e:
 
 html_theme = 'pydata_sphinx_theme'
 
-html_theme_options = {
-    'github_url': 'https://github.com/watts-dev/watts',
-}
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
 html_logo = '_static/watts.svg'
+
 html_theme_options = {
+    "github_url": "https://github.com/watts-dev/watts",
     "favicons": [
         {
             "rel": "icon",
@@ -86,5 +88,11 @@ html_theme_options = {
             "sizes": "32x32",
             "href": "watts_32x32.png",
         },
-    ]
+    ],
+    "switcher": {
+        "json_url": "https://watts.readthedocs.io/en/latest/_static/switcher.json",
+        "url_template": "https://watts.readthedocs.io/en/{version}/",
+        "version_match": version if '-dev' not in version else 'dev',
+    },
+    "navbar_end": ["version-switcher", "navbar-icon-links"]
 }

--- a/doc/source/dev/contributing.rst
+++ b/doc/source/dev/contributing.rst
@@ -114,3 +114,15 @@ Review Process
 Once your pull request is submitted, a member of the WATTS core development team
 will review your pull request. They will check your contribution against the
 above checklist to ensure that it is of sufficient quality.
+
+Installation for Developers
++++++++++++++++++++++++++++
+
+As a developer, it is advisable to install WATTS from the local source tree in
+"`editable <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_"
+mode::
+
+  pip install -e <path-to-watts-dir>
+
+This will install the package via a link to the original location so that any
+local changes are immediately reflected in your environment.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,27 @@
 [metadata]
 name = watts
-version = 0.0.1
+version = 0.1.0
 author = UChicago Argonne, LLC
 author_email = watts@anl.gov
 description = Workflow and Template Toolkit for Simulation
-long_description = file: README.md
+long_description =
+    WATTS (Workflow and Template Toolkit for Simulation) provides a set of
+    Python classes that can manage simulation workflows for multiple codes where
+    information is exchanged at a coarse level. For each code, input files rely
+    on placeholder values that are filled in based on a set of user-defined
+    parameters.
+
+    WATTS is being developed with support from Argonne National Laboratory. For
+    any questions, please contact [watts@anl.gov](mailto:watts@anl.gov).
 long_description_content_type = text/markdown
 license = MIT License
+url = https://github.com/watts-dev/watts
+project_urls =
+    Bug Tracker = https://github.com/watts-dev/watts/issues
+    Documentation = https://watts.readthedocs.io
+    Source Code = https://github.com/watts-dev/watts
 classifiers =
-    Development Status :: 2 - Pre-Alpha
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     Intended Audience :: End Users/Desktop
     Intended Audience :: Science/Research

--- a/src/watts/__init__.py
+++ b/src/watts/__init__.py
@@ -11,3 +11,5 @@ from .database import *
 
 # This allows a user to write watts.Quantity
 from astropy.units import Quantity
+
+__version__ = '0.1.0'


### PR DESCRIPTION
This PR adds a new GitHub action for publishing watts to PyPI whenever we tag a release. I've also bumped the version number to 0.1.0. Once this is merged, we can create a release on GitHub, and at that point the action will get triggered and upload it to PyPI. If it's successful (:crossed_fingers:), you'll then be able to `pip install watts`.