### PR TITLE
Update version number to 0.2.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
 ## [0.1.0]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = watts
-version = 0.1.0
+version = 0.2.0-dev
 author = UChicago Argonne, LLC
 author_email = watts@anl.gov
 description = Workflow and Template Toolkit for Simulation

--- a/src/watts/__init__.py
+++ b/src/watts/__init__.py
@@ -12,4 +12,4 @@ from .database import *
 # This allows a user to write watts.Quantity
 from astropy.units import Quantity
 
-__version__ = '0.1.0'
+__version__ = '0.2.0-dev'


### PR DESCRIPTION
Following the release of 0.1.0, this PR just updates the in-development version number to 0.2.0-dev. Note that I haven't bothered to go to 0.1.1-dev because apparently the watts project name on PyPI used to be owned by someone else and they had done a few releases under 0.1.x (this caused [some errors](https://github.com/watts-dev/watts/actions/runs/1895224948) when our GH action uploaded a package to PyPI). Moving to 0.2.x will avoid similar errors in the future.