### PR TITLE
Several small changes and doc fixes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,7 +48,8 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'openmc': ('https://docs.openmc.org/en/stable/', None),
-    'astropy': ('https://docs.astropy.org/en/stable/', None)
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'jinja2': ('https://jinja.palletsprojects.com/en/3.0.x/', None)
 }
 
 import watts

--- a/src/watts/parameters.py
+++ b/src/watts/parameters.py
@@ -76,6 +76,9 @@ class Parameters(MutableMapping):
     def __len__(self):
         return len(self._dict)
 
+    def __repr__(self):
+        return repr(self._dict)
+
     @property
     def warn_duplicates(self) -> bool:
         return self._warn_duplicates

--- a/src/watts/parameters.py
+++ b/src/watts/parameters.py
@@ -20,6 +20,7 @@ u.imperial.enable()
 
 ParametersMetadata = namedtuple('ParametersMetadata', ['user', 'time'])
 
+
 class Parameters(MutableMapping):
     """User parameters used to generate inputs that are created by plugins
 
@@ -234,7 +235,7 @@ class Parameters(MutableMapping):
         return params
 
     def convert_units(self, system: str = 'si', temperature: str = 'K',
-                     inplace: bool = False) -> Parameters:
+                      inplace: bool = False) -> Parameters:
         """Perform unit conversion
 
         Parameters

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -10,7 +10,7 @@ from .database import Database
 from .fileutils import cd_tmpdir, PathLike
 from .parameters import Parameters
 from .results import Results
-from .template import TemplateModelBuilder
+from .template import TemplateRenderer
 
 
 class Plugin(ABC):
@@ -107,9 +107,9 @@ class TemplatePlugin(Plugin):
         Extra (non-templated) input files
 
     """
-    def __init__(self, template_file: str, extra_inputs: Optional[List[PathLike]] = None):
+    def __init__(self, template_file: PathLike, extra_inputs: Optional[List[PathLike]] = None):
         super().__init__(extra_inputs)
-        self.model_builder = TemplateModelBuilder(template_file)
+        self.render_template = TemplateRenderer(template_file)
 
     def prerun(self, params: Parameters, filename: Optional[str] = None):
         """Render the template based on model parameters
@@ -119,7 +119,7 @@ class TemplatePlugin(Plugin):
         params
             Parameters used to render template
         filename
-            Keyword arguments passed to the
+            Filename for rendered template
         """
         # Render the template
-        self.model_builder(params, filename=filename)
+        self.render_template(params, filename=filename)

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -107,7 +107,7 @@ class TemplatePlugin(Plugin):
         Extra (non-templated) input files
 
     """
-    def  __init__(self, template_file: str, extra_inputs: Optional[List[PathLike]] = None):
+    def __init__(self, template_file: str, extra_inputs: Optional[List[PathLike]] = None):
         super().__init__(extra_inputs)
         self.model_builder = TemplateModelBuilder(template_file)
 

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -63,11 +63,13 @@ class ResultsMOOSE(Results):
         if csv_file.exists():
             csv_file_df = pd.read_csv(csv_file)
             for column_name in csv_file_df.columns:
-                csv_data[column_name] =  np.array(csv_file_df[column_name])
+                csv_data[column_name] = np.array(csv_file_df[column_name])
 
-        # Read MOOSE's vector postprocesssor '.csv' files and save the parameters as individual array
+        # Read MOOSE's vector postprocesssor '.csv' files and save the
+        # parameters as individual array
         for output in self.outputs:
-            if output.name.startswith(f"{input_file.stem}_csv_") and not output.name.endswith("_0000.csv"):
+            if (output.name.startswith(f"{input_file.stem}_csv_") and
+                not output.name.endswith("_0000.csv")):
                 vector_csv_df = pd.read_csv(output)
                 csv_param = list(set(vector_csv_df.columns) - {"id", "x", "y", "z"})
                 csv_data[output.stem] = np.array(vector_csv_df[csv_param[0]], dtype=float)
@@ -103,9 +105,9 @@ class PluginMOOSE(TemplatePlugin):
 
     """
 
-    def  __init__(self, template_file: str, show_stdout: bool = False,
-                  show_stderr: bool = False, n_cpu: int = 1,
-                  extra_inputs: Optional[List[str]] = None):
+    def __init__(self, template_file: str, show_stdout: bool = False,
+                 show_stderr: bool = False, n_cpu: int = 1,
+                 extra_inputs: Optional[List[str]] = None):
         super().__init__(template_file, extra_inputs)
         self._moose_exec = Path('moose-opt')
         self.moose_inp_name = "MOOSE.i"
@@ -163,7 +165,8 @@ class PluginMOOSE(TemplatePlugin):
             func_stdout = tee_stdout if self.show_stdout else redirect_stdout
             func_stderr = tee_stderr if self.show_stderr else redirect_stderr
             with func_stdout(outfile), func_stderr(outfile):
-                run_proc(["mpiexec", "-n", str(self.n_cpu) , self.moose_exec, "-i", self.moose_inp_name])
+                run_proc(["mpiexec", "-n", str(self.n_cpu), self.moose_exec,
+                          "-i", self.moose_inp_name])
 
     def postrun(self, params: Parameters) -> ResultsMOOSE:
         """Read MOOSE results and create results object

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -16,7 +16,7 @@ from .results import Results
 
 
 class ResultsPyARC(Results):
-    """OpenMC simulation results
+    """PyARC simulation results
 
     Parameters
     ----------
@@ -28,15 +28,14 @@ class ResultsPyARC(Results):
         List of input files
     outputs
         List of output files
-
-    Attributes
-    ----------
+    results_data
+        PyARC results
 
     """
 
     def __init__(self, params: Parameters, time: datetime,
-                 inputs: List[Path], outputs: List[Path], results_data):
-        super().__init__('PyARC', params, time, inputs, outputs, results_data)
+                 inputs: List[Path], outputs: List[Path], results_data: dict):
+        super().__init__('PyARC', params, time, inputs, outputs)
         self.results_data = results_data
 
     @property
@@ -65,9 +64,9 @@ class PluginPyARC(TemplatePlugin):
 
     """
 
-    def  __init__(self, template_file: str, show_stdout: bool = False,
-                  show_stderr: bool = False,
-                  extra_inputs: Optional[List[str]] = None):
+    def __init__(self, template_file: str, show_stdout: bool = False,
+                 show_stderr: bool = False,
+                 extra_inputs: Optional[List[str]] = None):
         super().__init__(template_file, extra_inputs)
         self._pyarc_exec = Path(os.environ.get('PyARC_DIR', 'PyARC.py'))
         self.pyarc_inp_name = "pyarc_input.son"
@@ -121,7 +120,7 @@ class PluginPyARC(TemplatePlugin):
         with tempfile.TemporaryDirectory() as tmpdir:
             self.pyarc.execute(["-i", self.pyarc_inp_name, "-w", tmpdir, "-o", str(od)], **kwargs)
         sys.path.pop(0)  # Restore sys.path to original state
-        os.chdir(od) # TODO: I don't know why but I keep going to self._pyarc_exec after execution - this is very wierd!
+        os.chdir(od)  # TODO: I don't know why but I keep going to self._pyarc_exec after execution - this is very wierd!
 
     def postrun(self, params: Parameters) -> ResultsPyARC:
         """Collect information from PyARC and create results object

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -1,5 +1,5 @@
-#SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
-#SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
+# SPDX-License-Identifier: MIT
 
 from datetime import datetime
 from pathlib import Path
@@ -30,7 +30,7 @@ class Results:
     """
 
     def __init__(self, plugin: str, params: Parameters, time: datetime,
-                 inputs: List[PathLike], outputs: List[PathLike], python_results = None):
+                 inputs: List[PathLike], outputs: List[PathLike]):
         self.base_path = Path.cwd()
         self.plugin = plugin
         self.parameters = Parameters(params)

--- a/src/watts/template.py
+++ b/src/watts/template.py
@@ -10,7 +10,16 @@ from .fileutils import PathLike
 from .parameters import Parameters
 
 
-class TemplateModelBuilder:
+class TemplateRenderer:
+    """Helper class for rendering a Jinja template
+
+    Parameters
+    ----------
+    template_file
+        Path to template file
+    **template_kwargs
+        Keywork arguments passed to :class:`jinja2.Template`
+    """
     def __init__(self, template_file: PathLike, **template_kwargs):
         self.template_file = Path(template_file)
         self.template = jinja2.Template(
@@ -20,6 +29,17 @@ class TemplateModelBuilder:
         )
 
     def __call__(self, params: Parameters, filename: Optional[PathLike] = None):
+        """Render the template
+
+        Parameters
+        ----------
+        params
+            User parameters used to fill placeholders
+        filename
+            Filename for rendered template (If none is provided, by default the
+            filename of the template is changed so that the new extension is
+            .rendered)
+        """
         # Default rendered template filename
         if filename is None:
             name = self.template_file.name


### PR DESCRIPTION
This PR makes a few small code changes:

- Fixes to conform to the PEP8 style guide
- Add missing docstrings for `TemplateModelBuilder`, which I've renamed `TemplateRenderer`
- Add a `__repr__` method for Parameters which gives a default dictionary-like string representation for Parameters, e.g.
    ```pycon
    >>> params = watts.Parameters(length=watts.Quantity(3., 'cm'), power=1e6)
    >>> params
    {'length': <Quantity 3. cm>, 'power': 1000000.0}

    ```
