### PR TITLE
Proposal: change "workflow" method to direct call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* SAS4A/SASSY-1 Plugin
+
 ### Changes
 
 * Serialization/deserialization handled through dill instead of h5py
+* Calling a plugin is called via the `__call__` method instead of `workflow`
 
 ## [0.1.0]
 

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -115,8 +115,8 @@ The SAM executable defaults to ``sam-opt`` (assumed to be present on your
 
     moose_plugin.moose_exec = "/path/to/sam-opt"
 
-To execute SAM, the :meth:`~watts.PluginMOOSE.workflow` method is called and
-expects to receive an instance of :class:`~watts.Parameters`. For the above
+To execute SAM, the :class:`~watts.PluginMOOSE` instance is called as a function
+and expects to receive an instance of :class:`~watts.Parameters`. For the above
 template, the :class:`~watts.Parameters` instance should have ``He_Pressure``,
 ``He_velocity``, and ``He_inlet_temp`` parameters present. Thus, executing SAM
 with this templated input file along with corresponding parameters might look as
@@ -126,10 +126,10 @@ follows::
     params['He_Pressure'] = 2.0
     params['He_velocity'] = 1.0
     params['He_inlet_temp'] = 600.0
-    results = moose_plugin.workflow(params)
+    results = moose_plugin(params)
 
-Calling the :meth:`~watts.PluginMOOSE.workflow` method will render the templated
-input file (replace variables with values from the :class:`~watts.Parameters`
+Calling the :class:`~watts.PluginMOOSE` instance will render the templated input
+file (replace variables with values from the :class:`~watts.Parameters`
 instance), execute SAM, and collect the output files.
 
 Beyond simple variable substitution, Jinja has sophisticated capabilities for
@@ -175,11 +175,11 @@ instantiated::
     openmc_plugin = watts.PluginOpenMC(godiva_model)
 
 Note how the function object itself is passed to the plugin. When the
-:meth:`~watts.PluginOpenMC.workflow` method is called, the "template" function
-is called and passed the user-specified :class:`~watts.Parameters`::
+:meth:`~watts.PluginOpenMC` instance is called, the "template" function is
+called and passed the user-specified :class:`~watts.Parameters`::
 
     params = watts.Parameters(radius=6.0)
-    results = openmc_plugin.workflow(params)
+    results = openmc_plugin(params)
 
 This will generate the OpenMC input files using the template parameters, run
 OpenMC, and collect the results.
@@ -209,8 +209,8 @@ The path to PyARC directory must be specified explicitly with the
 
     pyarc_plugin.pyarc_exec  = "/path/to/PyARC"
 
-To execute PyARC, the :meth:`~watts.PluginPyARC.workflow` method is called
-the same way as other Plugins.
+To execute PyARC, the :meth:`~watts.PluginPyARC` instance is called directly the
+same way as other plugins.
 
 SAS4A/SASSY-1 Plugin
 ~~~~~~~~~~~~~~~~~~~~
@@ -223,38 +223,42 @@ input files which can be templated as follows:
 
     47    1        {{ flow_per_pin }}
     3     1 {{ total_reactor_power }}
-    7     1                {{ tmax }} 
+    7     1                {{ tmax }}
 
 If the templated input file is `sas_template`, then the SAS4A/SASSY-1 plugin can be
 instantiated with the following command line::
 
     sas_plugin = watts.PluginSAS('sas_template', show_stdout=True)
 
-The SAS executable is OS-dependent. It defaults to ``sas.x`` (assumed to be present on your
-:envvar:`PATH`) for Linux and macOS, and ``sas.exe`` for Windows. However, the executable can also be specified explicitly with the
+The SAS executable is OS-dependent. It defaults to ``sas.x`` (assumed to be
+present on your :envvar:`PATH`) for Linux and macOS, and ``sas.exe`` for
+Windows. However, the executable can also be specified explicitly with the
 :attr:`~watts.PluginSAS.sas_exec` attribute::
 
     sas_plugin.sas_exec = "/path/to/sas-exec"
 
-Furthermore, the paths to the SAS utilities that convert the ".dat" files to ".csv" files must be specified with the :attr:`~watts.PluginSAS.conv_channel` and :attr:`~watts.PluginSAS.conv_primar4` attributes::
+Furthermore, the paths to the SAS utilities that convert the ".dat" files to
+".csv" files must be specified with the :attr:`~watts.PluginSAS.conv_channel`
+and :attr:`~watts.PluginSAS.conv_primar4` attributes::
 
     sas_plugin.conv_channel  = "/path/to/CHANNELtoCSV.x"
     sas_plugin.conv_primar4  = "/path/to/PRIMAR4toCSV.x"
 
-Similar to the SAS executable, the utilities are also OS dependent. To execute SAS, the :meth:`~watts.PluginSAS.workflow` method is called
-the same way as other Plugins.
+Similar to the SAS executable, the utilities are also OS dependent. To execute
+SAS, the :meth:`~watts.PluginSAS` instance is called directly in the same way as
+other plugins.
 
 Results
 +++++++
 
-When you run the :meth:`~watts.Plugin.workflow` method on a plugin, an instance
-of the :class:`~watts.Results` class specific to the plugin will be returned
-that contains information about the results. Every :class:`~watts.Results`
-object contains a list of input and output files that were generated:
+When you call a :meth:`~watts.Plugin` instance, an instance of the
+:class:`~watts.Results` class specific to the plugin will be returned that
+contains information about the results. Every :class:`~watts.Results` object
+contains a list of input and output files that were generated:
 
 .. code-block:: pycon
 
-    >>> results = plugin_openmc.workflow(params)
+    >>> results = plugin_openmc(params)
     >>> results.inputs
     [PosixPath('geometry.xml'),
      PosixPath('settings.xml'),
@@ -265,7 +269,7 @@ object contains a list of input and output files that were generated:
      PosixPath('statepoint.250.h5')]
 
 :class:`~watts.Results` objects also contain a copy of the
-:class:`~watts.Parameters` that were used at the time the workflow was run:
+:class:`~watts.Parameters` that were used at the time the plugin was called:
 
 .. code-block:: pycon
 
@@ -290,7 +294,7 @@ For MOOSE, the :class:`~watts.ResultsMOOSE` class provides a
 :attr:`~watts.ResultsMOOSE.csv_data` attribute that gathers the results from
 every CSV files generated by MOOSE applications (such as SAM or BISON)::
 
-    moose_result = moose_plugin.workflow(params)
+    moose_result = moose_plugin(params)
     for key in moose_result.csv_data:
         print(key, moose_result.csv_data[key])
 
@@ -299,25 +303,25 @@ For PyARC, the :class:`~watts.ResultsPyARC` class
 provides a :attr:`~watts.ResultsPyARC.results_data` attribute that gathers the
 results stored in `PyARC.user_object`::
 
-    pyarc_result = pyarc_plugin.workflow(params)
+    pyarc_result = pyarc_plugin(params)
     for key in pyarc_result.results_data:
         print(key, pyarc_result.results_data[key])
 
 Database
 ++++++++
 
-When you call the :meth:`~watts.Plugin.workflow` method on a plugin, the
-:class:`~watts.Results` object and all accompanying files are automatically
-added to a database on disk for later retrieval. Interacting with this database
-can be done via the :class:`~watts.Database` class:
+When you call a :class:`~watts.Plugin` instance, the :class:`~watts.Results`
+object and all accompanying files are automatically added to a database on disk
+for later retrieval. Interacting with this database can be done via the
+:class:`~watts.Database` class:
 
 .. code-block:: pycon
 
     >>> db = watts.Database()
     >>> db.results
-    [<watts.plugin_openmc.ResultsOpenMC at 0x15530416bfd0>,
-     <watts.plugin_openmc.ResultsOpenMC at 0x15530416bbb0>,
-     <watts.plugin_moose.ResultsMOOSE at 0x1553043c8a30>]
+    [<ResultsOpenMC: 2022-01-01 12:05:02.130384>,
+     <ResultsOpenMC: 2022-01-01 12:11:38.037813>,
+     <ResultsMOOSE: 2022-01-02 08:45:12.846409>]
 
 By default, the database will be created in a user-specific data directory (on
 Linux machines, this is normally within ``~/.local/share``). However, the
@@ -326,9 +330,8 @@ location of the database can be specified::
     db = watts.Database('/opt/watts_db/')
 
 Creating a database this way doesn't change the default path used when running
-plugin workflows. If you want to change the default database path used in
-workflows, the :meth:`~watts.Database.set_default_path` classmethod should be
-used::
+plugins. If you want to change the default database path used in plugins, the
+:meth:`~watts.Database.set_default_path` classmethod should be used::
 
     >>> watts.Database.set_default_path('/opt/watts_db')
     >>> db = watts.Database()

--- a/examples/example1a_SAM/example1a.py
+++ b/examples/example1a_SAM/example1a.py
@@ -49,7 +49,7 @@ moose_app_type = "SAM"
 app_dir = os.environ[moose_app_type.upper() + "_DIR"]
 moose_plugin = watts.PluginMOOSE(moose_app_type.lower() + '_template') # show all the output
 moose_plugin.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result = moose_plugin.workflow(params)
+moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])
 print(moose_result.inputs)

--- a/examples/example1b_BISON/example1b.py
+++ b/examples/example1b_BISON/example1b.py
@@ -44,7 +44,7 @@ moose_app_type = "bison"
 app_dir = os.environ[moose_app_type.upper() + "_DIR"]
 moose_plugin = watts.PluginMOOSE(moose_app_type.lower() + '_template', show_stdout=True, n_cpu=2) # show all the output
 moose_plugin.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result = moose_plugin.workflow(params)
+moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])
 print(moose_result.inputs)

--- a/examples/example1c_PyARC/example1c.py
+++ b/examples/example1c_PyARC/example1c.py
@@ -15,7 +15,7 @@ params.show_summary(show_metadata=False, sort_by='key')
 # PyARC Workflow
 
 pyarc_plugin = watts.PluginPyARC('pyarc_template', show_stdout=True, extra_inputs=['lumped_test5.son']) # show all the output
-pyarc_result = pyarc_plugin.workflow(params)
+pyarc_result = pyarc_plugin(params)
 for key in pyarc_result.results_data:
     print(key, pyarc_result.results_data[key])
 print(pyarc_result.inputs)

--- a/examples/example2_SAM_OpenMC/example2.py
+++ b/examples/example2_SAM_OpenMC/example2.py
@@ -62,7 +62,7 @@ moose_app_type = "SAM"
 app_dir = os.environ[moose_app_type.upper() + "_DIR"]
 moose_plugin = watts.PluginMOOSE('../example1a_SAM/sam_template', show_stderr=True) # show only error
 moose_plugin.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result = moose_plugin.workflow(params)
+moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])
 print(moose_result.inputs)
@@ -77,7 +77,7 @@ params.show_summary(show_metadata=False, sort_by='time')
 
 # Run OpenMC plugin
 openmc_plugin = watts.PluginOpenMC(build_openmc_model, show_stderr=True) # show only error
-openmc_result = openmc_plugin.workflow(params)
+openmc_result = openmc_plugin(params)
 print("KEFF = ", openmc_result.keff)
 print(openmc_result.inputs)
 print(openmc_result.outputs)

--- a/examples/example3_iterations/example3.py
+++ b/examples/example3_iterations/example3.py
@@ -63,7 +63,7 @@ while conv_it:
     app_dir = os.environ[moose_app_type.upper() + "_DIR"]
     sam_plugin = watts.PluginMOOSE('../example1a_SAM/sam_template', show_stderr=True) # show only error
     sam_plugin.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-    sam_result = sam_plugin.workflow(params)
+    sam_result = sam_plugin(params)
 
     # get temperature from SAM results
     params['temp'] = mean([sam_result.csv_data[f'avg_Tgraphite_{i}'][-1] for i in range(1, 6)])
@@ -74,7 +74,7 @@ while conv_it:
 
     # Run OpenMC plugin
     openmc_plugin = watts.PluginOpenMC(build_openmc_model, show_stderr=True) # show only error
-    openmc_result = openmc_plugin.workflow(params)
+    openmc_result = openmc_plugin(params)
     print("KEFF = ", openmc_result.keff)
     list_keff.append(openmc_result.keff)
 

--- a/examples/example4_main/example4.py
+++ b/examples/example4_main/example4.py
@@ -63,7 +63,7 @@ def calc_workflow(X):
     app_dir = os.environ[moose_app_type.upper() + "_DIR"]
     sam_plugin = watts.PluginMOOSE('../example1a_SAM/sam_template', show_stderr=False) # does not show anything
     sam_plugin.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-    sam_result = sam_plugin.workflow(params)
+    sam_result = sam_plugin(params)
     max_Tf = max(sam_result.csv_data[f'max_Tf_{i}'][-1] for i in range(1, 6))
     avg_Tf = mean(sam_result.csv_data[f'avg_Tf_{i}'][-1] for i in range(1, 6))
     print("MaxTfuel / AvgTfuel= ", max_Tf, avg_Tf)
@@ -75,7 +75,7 @@ def calc_workflow(X):
 
     # Run OpenMC plugin
     openmc_plugin = watts.PluginOpenMC(build_openmc_model, show_stderr=False) # does not show anything
-    openmc_result = openmc_plugin.workflow(params)
+    openmc_result = openmc_plugin(params)
     print("KEFF = ", openmc_result.keff)
 
     return (openmc_result.keff.n, max_Tf, avg_Tf)

--- a/examples/example5_multiapps/example5a.py
+++ b/examples/example5_multiapps/example5a.py
@@ -20,7 +20,7 @@ moose_app_type = "bison"
 app_dir = os.environ[moose_app_type.upper() + "_DIR"]
 moose_plugin = watts.PluginMOOSE('main.tmpl', extra_inputs=['main_in.e', 'sub.i'])
 moose_plugin.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result = moose_plugin.workflow(params)
+moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])
 print(moose_result.inputs)

--- a/examples/example6_adv_multiapps/example6.py
+++ b/examples/example6_adv_multiapps/example6.py
@@ -41,7 +41,7 @@ params_ss.show_summary(show_metadata=False, sort_by='key')
 print("Steady-state calculation")
 moose_plugin_ss = watts.PluginMOOSE('MP_ss_griffin.tmpl', n_cpu=40, extra_inputs=['MP_ss_moose.i', 'MP_ss_sockeye.i', '3D_unit_cell_FY21_level-1_bison.e', '3D_unit_cell_FY21_supersimple.e', 'unitcell_nogap_hom_xml_G11_df_MP.xml'])
 moose_plugin_ss.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result_ss = moose_plugin_ss.workflow(params_ss)
+moose_result_ss = moose_plugin_ss(params_ss)
 for key in moose_result_ss.csv_data:
     print(key, moose_result_ss.csv_data[key])
 print(moose_result_ss.inputs)
@@ -57,7 +57,7 @@ params_trN = params_ss
 print("Null transient calculation")
 moose_plugin_trN = watts.PluginMOOSE('MP_trN_griffin.tmpl', n_cpu=40, show_stdout=False, extra_inputs=['MP_trN_moose.i', 'MP_trN_sockeye.i', 'unitcell_nogap_hom_xml_G11_df_MP.xml'])
 moose_plugin_trN.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result_trN = moose_plugin_trN.workflow(params_trN)
+moose_result_trN = moose_plugin_trN(params_trN)
 for key in moose_result_trN.csv_data:
     print(key, moose_result_trN.csv_data[key])
 print(moose_result_trN.inputs)
@@ -77,7 +77,7 @@ params_tr = params_ss
 print("Transient calculation")
 moose_plugin_tr = watts.PluginMOOSE('MP_tr_griffin.tmpl', n_cpu=40, show_stdout=True, extra_inputs=['MP_tr_moose.i', 'MP_tr_sockeye.i', 'unitcell_nogap_hom_xml_G11_df_MP.xml'])
 moose_plugin_tr.moose_exec = app_dir + "/" + moose_app_type.lower() + "-opt"
-moose_result_tr = moose_plugin_tr.workflow(params_tr)
+moose_result_tr = moose_plugin_tr(params_tr)
 for key in moose_result_tr.csv_data:
     print(key, moose_result_tr.csv_data[key])
 print(moose_result_tr.inputs)

--- a/examples/example7a_SAS/example7a.py
+++ b/examples/example7a_SAS/example7a.py
@@ -3,10 +3,10 @@
 
 """
 Example problem of runing SAS4A/SASSY-1 with WATTS.
-This is a steady-state, single pin problem with uniform 
+This is a steady-state, single pin problem with uniform
 dimensions and constant properties. The fuel pin has a
-constant linear heat generation and the boundaries of 
-the problem are the top and bottom of the fuel pin. 
+constant linear heat generation and the boundaries of
+the problem are the top and bottom of the fuel pin.
 Sodium coolant enters from the bottom. The fuel pin is
 separated into a bottom unheated section, fuel section,
 gas plenum, and top unheated section. This problem DOES
@@ -25,7 +25,7 @@ params = watts.Parameters()
 params['sas_version'] = 5.5
 params['tmax'] = 400.0 # maximum problem time in s
 params['flow_per_pin'] = 0.15 # kg/s
-params['total_reactor_power'] = Quantity(182, "MW") 
+params['total_reactor_power'] = Quantity(182, "MW")
 params['betai_1'] = 2.0E-04 # Effective delayed neutron fraction
 params['betai_2'] = 1.0E-03
 params['betai_3'] = 1.2E-03
@@ -37,7 +37,7 @@ params.show_summary(show_metadata=False, sort_by='key')
 
 # SAS Workflow
 sas_plugin = watts.PluginSAS('sas_template') # Show all the output
-sas_result = sas_plugin.workflow(params)
+sas_result = sas_plugin(params)
 for key in sas_result.csv_data:
     print(key, sas_result.csv_data[key])
 print(sas_result.inputs)

--- a/examples/example7b_SAS/example7b.py
+++ b/examples/example7b_SAS/example7b.py
@@ -7,7 +7,7 @@ This is a simple sodium loop that uses the channel (core)
 and PRIMAR-4 module. Sodium is heated in the core, then
 flows upwward through a series of pipes to a heat
 exchanger (IHX), then downward to a pump, and lastly
-back to the outlet of the core. A tank with cover gas is 
+back to the outlet of the core. A tank with cover gas is
 used to provide compressible space. The design of
 loop is a simplified version of the loop by Zhang et al.
 (https://doi.org/10.1016/j.nucengdes.2021.111149). The
@@ -27,7 +27,7 @@ dimensions of this simplified loop are arbitrarily selected.
    *                     |
    *                     |
    *                     |
-   *  C                  |                
+   *  C                  |
    *  O                  |              ____________
    *  R                  |             |            |
    *  R                  |             |            |
@@ -39,7 +39,7 @@ dimensions of this simplified loop are arbitrarily selected.
    *                   [    ]          |            |
     -------------------[    ]----------|____________|
                        [____]               TANK
-                        PUMP 
+                        PUMP
 """
 
 from math import cos, pi
@@ -66,7 +66,7 @@ params.show_summary(show_metadata=False, sort_by='key')
 
 # SAS Workflow
 sas_plugin = watts.PluginSAS('sas_template') # Show all the output
-sas_result = sas_plugin.workflow(params)
+sas_result = sas_plugin(params)
 for key in sas_result.csv_data:
     print(key, sas_result.csv_data[key])
 print(sas_result.inputs)

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -52,7 +52,7 @@ class Plugin(ABC):
                 return path / unique_name
             i += 1
 
-    def workflow(self, params: Parameters, name='Workflow') -> Results:
+    def __call__(self, params: Parameters, name='Workflow') -> Results:
         """Run the complete workflow for the plugin
 
         Parameters

--- a/tests/test_plugin_openmc.py
+++ b/tests/test_plugin_openmc.py
@@ -37,7 +37,7 @@ def test_openmc_plugin():
     assert plugin.model_builder == build_openmc_model
 
     params = watts.Parameters(radius=6.38)
-    result = plugin.workflow(params)
+    result = plugin(params)
 
     # Sanity checks
     assert isinstance(result, watts.ResultsOpenMC)
@@ -88,7 +88,7 @@ def test_extra_inputs(run_in_tmpdir):
     # Use OpenMC plugin with extra inputs
     plugin = watts.PluginOpenMC(extra_inputs=['geometry.xml', 'materials.xml', 'settings.xml'])
     params = watts.Parameters()
-    result = plugin.workflow(params)
+    result = plugin(params)
 
     input_names = {p.name for p in result.inputs}
     assert input_names == {'geometry.xml', 'materials.xml', 'settings.xml'}


### PR DESCRIPTION
Currently, our plugin classes work by exposing a `workflow` method. A more common design pattern is to have these classes be "functors" where the instances of the class can be called directly like a function. That is, instead of:
```Python
plugin = watts.Plugin(...)
result = plugin.workflow(params)
```
we'd have
```Python
plugin = watts.Plugin()
result = plugin(params)
```
To me, it's more clear that the second example corresponds to "calling the plugin" whereas for the first example, the meaning of "workflow" isn't that clear. I'm curious to hear what others think about this change though.