### PR TITLE
Several small updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+* The `Plugin.__call__` method now allows arbitrary keyword arguments to be
+  passed on to the `Plugin.run` method
+* The `Database` class now acts like a sequence
+
 ## [0.2.0]
 
 ### Added

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -182,7 +182,10 @@ called and passed the user-specified :class:`~watts.Parameters`::
     results = openmc_plugin(params)
 
 This will generate the OpenMC input files using the template parameters, run
-OpenMC, and collect the results.
+OpenMC, and collect the results. Note that any extra keyword arguments passed to
+the plugin are forwarded to the :func:`openmc.run` function. For example::
+
+    results = openmc_plugin(params, mpi_args=["mpiexec", "-n", "16"])
 
 PyARC Plugin
 ~~~~~~~~~~~~~

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -318,10 +318,12 @@ for later retrieval. Interacting with this database can be done via the
 .. code-block:: pycon
 
     >>> db = watts.Database()
-    >>> db.results
+    >>> db
     [<ResultsOpenMC: 2022-01-01 12:05:02.130384>,
      <ResultsOpenMC: 2022-01-01 12:11:38.037813>,
      <ResultsMOOSE: 2022-01-02 08:45:12.846409>]
+    >>> db[1]
+    <ResultsOpenMC: 2022-01-01 12:11:38.037813>
 
 By default, the database will be created in a user-specific data directory (on
 Linux machines, this is normally within ``~/.local/share``). However, the
@@ -344,7 +346,7 @@ To clear results from the database, simply use the
 .. code-block::
 
     >>> db.clear()
-    >>> db.results
+    >>> db
     []
 
 Be aware that clearing the database **will** delete all the corresponding

--- a/src/watts/database.py
+++ b/src/watts/database.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Sequence
 from pathlib import Path
+import pprint
 import shutil
 from typing import List, Union
 from warnings import warn
@@ -11,7 +13,7 @@ import platformdirs
 from .results import Results
 
 
-class Database:
+class Database(Sequence):
     """Database of simulation results
 
     Parameters
@@ -71,6 +73,15 @@ class Database:
         # Add instance to class-wide dictionary
         Database._instances[path.resolve()] = self
 
+    def __repr__(self):
+        return pprint.pformat(self._results)
+
+    def __getitem__(self, index):
+        return self._results[index]
+
+    def __len__(self):
+        return len(self._results)
+
     @property
     def path(self) -> Path:
         return self._path
@@ -105,10 +116,6 @@ class Database:
         """
         return cls._default_path
 
-    @property
-    def results(self) -> List[Results]:
-        return self._results
-
     def add_result(self, result: Results):
         """Add a result to the database
 
@@ -127,11 +134,11 @@ class Database:
         """Remove all results from database"""
         for dir in self.path.iterdir():
             shutil.rmtree(dir)
-        self.results.clear()
+        self._results.clear()
 
     def show_summary(self):
         """Show a summary of results in database"""
-        for result in self.results:
+        for result in self._results:
             rel_path = result.base_path.relative_to(self.path)
             print(result.time, result.plugin, str(rel_path),
                   f"({len(result.inputs)} inputs)",

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -52,7 +52,7 @@ class Plugin(ABC):
                 return path / unique_name
             i += 1
 
-    def __call__(self, params: Parameters, name='Workflow') -> Results:
+    def __call__(self, params: Parameters, name: str = 'Workflow', **kwargs) -> Results:
         """Run the complete workflow for the plugin
 
         Parameters
@@ -61,6 +61,8 @@ class Plugin(ABC):
             Parameters used in generating inputs
         name
             Unique name for workflow
+        **kwargs
+            Keyword arguments passed to the `run` method
 
         Returns
         -------
@@ -76,7 +78,7 @@ class Plugin(ABC):
 
             # Run workflow in temporary directory
             self.prerun(params)
-            self.run()
+            self.run(**kwargs)
             result = self.postrun(params)
 
             # Create new directory for results and move files there

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -185,6 +185,6 @@ class PluginMOOSE(TemplatePlugin):
         time = datetime.fromtimestamp(self._run_time * 1e-9)
         # Start with non-templated input files
         inputs = [p.name for p in self.extra_inputs]
-        inputs.append('MOOSE.i')
+        inputs.append(self.moose_inp_name)
         outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
         return ResultsMOOSE(params, time, inputs, outputs)

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -98,7 +98,7 @@ class PluginSAS(TemplatePlugin):
 
         # Check OS to make sure the extension of the executable is correct.
         # Linux and macOS have different executables but both are ".x".
-        # The Windows executable is ".exe". 
+        # The Windows executable is ".exe".
         sas_dir = Path(os.environ.get("SAS_DIR", ""))
         ext = "exe" if platform.system() == "Windows" else "x"
         self._sas_exec = sas_dir / f"sas.{ext}"
@@ -189,7 +189,7 @@ class PluginSAS(TemplatePlugin):
         if Path("CHANNEL.dat").is_file():
             with open("CHANNEL.dat", "r") as file_in, open("CHANNEL.csv", "w") as file_out:
                 subprocess.run(str(self.conv_channel), stdin=file_in, stdout=file_out)
-                
+
         if Path("PRIMAR4.dat").is_file():
             with open("PRIMAR4.dat", "r") as file_in, open("PRIMAR4.csv", "w") as file_out:
                 subprocess.run(str(self.conv_primar4), stdin=file_in, stdout=file_out)
@@ -197,6 +197,6 @@ class PluginSAS(TemplatePlugin):
         time = datetime.fromtimestamp(self._run_time * 1e-9)
         # Start with non-templated input files
         inputs = [p.name for p in self.extra_inputs]
-        inputs.append('SAS.inp')
+        inputs.append(self.sas_inp_name)
         outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
         return ResultsSAS(params, time, inputs, outputs)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -59,8 +59,8 @@ def test_add_results(run_in_tmpdir):
     db.add_result(get_result())
 
     # Basic sanity checks
-    assert len(db.results) == 2
-    for result in db.results:
+    assert len(db) == 2
+    for result in db:
         assert isinstance(result, watts.ResultsOpenMC)
         assert result.parameters['value'] == 1
         assert result.parameters['lab'] == 'Argonne'
@@ -69,4 +69,4 @@ def test_add_results(run_in_tmpdir):
 
     # Ensure database can be cleared
     db.clear()
-    assert len(db.results) == 0
+    assert len(db) == 0

--- a/tests/test_plugin_openmc.py
+++ b/tests/test_plugin_openmc.py
@@ -63,7 +63,7 @@ def test_openmc_plugin():
 
     # Make sure result was added to database and agrees
     db = watts.Database()
-    last_result = db.results[-1]
+    last_result = db[-1]
     assert last_result.parameters['radius'] == result.parameters['radius']
     assert last_result.inputs == result.inputs
     assert last_result.outputs == result.outputs


### PR DESCRIPTION
This PR makes a few small changes:

- Consistent use of the `moose_inp_name` and `sas_inp_name` attributes
- `Plugin.__call__` now takes keyword arguments that get passed on to the `run` method (this allows a user to, e.g., pass arguments to `openmc.run`)
- The `Database` class now appears to the user like a list, so they can index it directly rather than having to write `database.results`