### PR TITLE
Allow extra templated input files

### DIFF
--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -107,11 +107,17 @@ class TemplatePlugin(Plugin):
         Path to template file
     extra_inputs
         Extra (non-templated) input files
+    extra_template_inputs
+        Extra templated input files
 
     """
-    def __init__(self, template_file: PathLike, extra_inputs: Optional[List[PathLike]] = None):
+    def __init__(self, template_file: PathLike, extra_inputs: Optional[List[PathLike]] = None,
+                 extra_template_inputs: Optional[List[PathLike]] = None):
         super().__init__(extra_inputs)
         self.render_template = TemplateRenderer(template_file)
+        self.extra_render_templates = []
+        if extra_template_inputs is not None:
+            self.extra_render_templates = [TemplateRenderer(f, '') for f in extra_template_inputs]
 
     def prerun(self, params: Parameters, filename: Optional[str] = None):
         """Render the template based on model parameters
@@ -125,3 +131,5 @@ class TemplatePlugin(Plugin):
         """
         # Render the template
         self.render_template(params, filename=filename)
+        for render_template in self.extra_render_templates:
+            render_template(params)

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from pathlib import Path
 import shutil
 from typing import Optional, List
@@ -118,6 +119,26 @@ class TemplatePlugin(Plugin):
         self.extra_render_templates = []
         if extra_template_inputs is not None:
             self.extra_render_templates = [TemplateRenderer(f, '') for f in extra_template_inputs]
+
+    def _get_result_input(self, input_filename: str):
+        """Get the data needed to create the postrun results object
+
+        Parameters
+        ----------
+        input_filename
+            Name of the input file for the plugin code
+
+        Returns
+        -------
+        tuple of data used to create the results object
+        """
+        time = datetime.fromtimestamp(self._run_time * 1e-9)
+        inputs = [p.name for p in self.extra_inputs]
+        inputs.append(input_filename)
+        for renderer in self.extra_render_templates:
+            inputs.append(renderer.template_file.name)
+        outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
+        return time, inputs, outputs
 
     def prerun(self, params: Parameters, filename: Optional[str] = None):
         """Render the template based on model parameters

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -182,11 +182,5 @@ class PluginMOOSE(TemplatePlugin):
         """
         print("Post-run for MOOSE Plugin")
 
-        time = datetime.fromtimestamp(self._run_time * 1e-9)
-        # Start with non-templated input files
-        inputs = [p.name for p in self.extra_inputs]
-        inputs.append(self.moose_inp_name)
-        for renderer in self.extra_render_templates:
-            inputs.append(renderer.template_file.name)
-        outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
+        time, inputs, outputs = self._get_result_input(self.moose_inp_name)
         return ResultsMOOSE(params, time, inputs, outputs)

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -186,5 +186,7 @@ class PluginMOOSE(TemplatePlugin):
         # Start with non-templated input files
         inputs = [p.name for p in self.extra_inputs]
         inputs.append(self.moose_inp_name)
+        for renderer in self.extra_render_templates:
+            inputs.append(renderer.template_file.name)
         outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
         return ResultsMOOSE(params, time, inputs, outputs)

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -139,5 +139,7 @@ class PluginPyARC(TemplatePlugin):
         time = datetime.fromtimestamp(self._run_time * 1e-9)
         inputs = [p.name for p in self.extra_inputs]
         inputs.append(self.pyarc_inp_name)
+        for renderer in self.extra_render_templates:
+            inputs.append(renderer.template_file.name)
         outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
         return ResultsPyARC(params, time, inputs, outputs, self.pyarc.user_object.results)

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -136,10 +136,5 @@ class PluginPyARC(TemplatePlugin):
         """
         print("Post-run for PyARC Plugin")
 
-        time = datetime.fromtimestamp(self._run_time * 1e-9)
-        inputs = [p.name for p in self.extra_inputs]
-        inputs.append(self.pyarc_inp_name)
-        for renderer in self.extra_render_templates:
-            inputs.append(renderer.template_file.name)
-        outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
+        time, inputs, outputs = self._get_result_input(self.pyarc_inp_name)
         return ResultsPyARC(params, time, inputs, outputs, self.pyarc.user_object.results)

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -198,5 +198,7 @@ class PluginSAS(TemplatePlugin):
         # Start with non-templated input files
         inputs = [p.name for p in self.extra_inputs]
         inputs.append(self.sas_inp_name)
+        for renderer in self.extra_render_templates:
+            inputs.append(renderer.template_file.name)
         outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
         return ResultsSAS(params, time, inputs, outputs)

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -194,11 +194,5 @@ class PluginSAS(TemplatePlugin):
             with open("PRIMAR4.dat", "r") as file_in, open("PRIMAR4.csv", "w") as file_out:
                 subprocess.run(str(self.conv_primar4), stdin=file_in, stdout=file_out)
 
-        time = datetime.fromtimestamp(self._run_time * 1e-9)
-        # Start with non-templated input files
-        inputs = [p.name for p in self.extra_inputs]
-        inputs.append(self.sas_inp_name)
-        for renderer in self.extra_render_templates:
-            inputs.append(renderer.template_file.name)
-        outputs = [p for p in Path.cwd().iterdir() if p.name not in inputs]
+        time, inputs, outputs = self._get_result_input(self.sas_inp_name)
         return ResultsSAS(params, time, inputs, outputs)

--- a/src/watts/template.py
+++ b/src/watts/template.py
@@ -20,13 +20,14 @@ class TemplateRenderer:
     **template_kwargs
         Keywork arguments passed to :class:`jinja2.Template`
     """
-    def __init__(self, template_file: PathLike, **template_kwargs):
+    def __init__(self, template_file: PathLike, suffix: str = '.rendered', **template_kwargs):
         self.template_file = Path(template_file)
         self.template = jinja2.Template(
             self.template_file.read_text(),
             undefined=jinja2.StrictUndefined,
             **template_kwargs
         )
+        self.suffix = suffix
 
     def __call__(self, params: Parameters, filename: Optional[PathLike] = None):
         """Render the template
@@ -43,7 +44,7 @@ class TemplateRenderer:
         # Default rendered template filename
         if filename is None:
             name = self.template_file.name
-            out_path = self.template_file.with_name(f'{name}.rendered')
+            out_path = self.template_file.with_name(f'{name}{self.suffix}')
         else:
             out_path = Path(filename)
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -20,14 +20,34 @@ def test_undefined_template(run_in_tmpdir):
     # Create plugin to build template
     plugin = TemplatePlugin('example_template')
 
-    # Passing model with 'variable' set should work
-    model = watts.Parameters(variable=1)
-    plugin.prerun(model)
+    # Passing parameters with 'variable' set should work
+    params = watts.Parameters(variable=1)
+    plugin.prerun(params)
     with open('example_template.rendered', 'r') as fh:
         rendered = fh.read()
     assert rendered == '1'
 
-    # Passing empty model should raise jinja2.UndefinedError
-    empty_model = watts.Parameters()
+    # Passing empty parameters should raise jinja2.UndefinedError
+    empty_params = watts.Parameters()
     with pytest.raises(jinja2.UndefinedError) as e:
-        plugin.prerun(empty_model)
+        plugin.prerun(empty_params)
+
+def test_extra_template_inputs(run_in_tmpdir):
+    # Create templates expecting a variable
+    with open('main_template', 'w') as fh:
+        fh.write("{{ x }}")
+    with open('extra_template', 'w') as fh:
+        fh.write("{{ y }}")
+
+    # Create plugin to build template
+    plugin = TemplatePlugin('main_template', extra_template_inputs=['extra_template'])
+
+    # Pass parameters with 'x' and 'y' set
+    params = watts.Parameters(x=1, y=2)
+    plugin.prerun(params)
+    with open('main_template.rendered', 'r') as fh:
+        rendered = fh.read()
+    assert rendered == '1'
+    with open('extra_template', 'r') as fh:
+        rendered = fh.read()
+    assert rendered == '2'


### PR DESCRIPTION
This PR modifies the `Plugin` class to accept extra templated input files (see #13):

`watts.PluginX('main_tmpl', extra_inputs=['extra_inp'], extra_template_inputs=['extra_tmpl1, 'extra_tmpl2'])`

It also adds a unit test and reduces some of the code duplication in the plugin `postrun` methods.