### PR TITLE
RELAP5-3D plugin

### DIFF
--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -219,7 +219,7 @@ SAS4A/SASSY-1 Plugin
 ~~~~~~~~~~~~~~~~~~~~
 
 The :class:`~watts.PluginSAS` class handles SAS4A/SASSY-1 execution in a similar
-manner to the :class:`~watts.PluginMOOSE` class for MOOSE. SAS4A/SASSY-1 use text-based
+manner to the :class:`~watts.PluginMOOSE` class for MOOSE. SAS4A/SASSY-1 uses text-based
 input files which can be templated as follows:
 
 .. code-block:: jinja
@@ -251,14 +251,57 @@ Similar to the SAS executable, the utilities are also OS dependent. To execute
 SAS, the :meth:`~watts.PluginSAS` instance is called directly in the same way as
 other plugins.
 
-WATTS also supports the "INCLUDE" directive of SAS that allows for multiple input
-files. Users simply need to add "INCLUDE extra_input_file_names" to the template
-and specify the names of the extra input files as a string to the
-"extra_template_inputs" argument when calling the :class:`~watts.PluginSAS` class::
+SAS4A/SASSY-1 Plugin
+~~~~~~~~~~~~~~~~~~~~
 
-    sas_plugin = watts.PluginSAS('sas_template', show_stdout=True, extra_template_inputs=['extra_input_file_names'])
+The :class:`~watts.PluginRELAP5` class handles execution of RELAP5-3D. Note that the 
+plugin is designed for the execution of RELAP5-3D v4.3.4 and thus may not be compatible
+with other version of RELAP5-3D. RELAP5-3D uses text-based input files that can be 
+templated as follows:
 
-An example has been provided to demonstrate this capability.
+.. code-block:: jinja
+
+*                 Time         Power
+20250001          -1.0         0.0
+20250002           0.0      {{ heater_power_1 }}
+20250003         1.0e3      {{ heater_power_2 }}
+
+If the templated input file is `relap5_template`, then the RELAP5-3D plugin can be
+instantiated with the following command line::
+
+    relap5_plugin = watts.PluginRELAP5('relap5_template', show_stdout=True)
+
+RELAP5-3D requires the executable, license key, and the input file to be in the same
+directory to run. Thus, before running the RELAP5-3D plugin, user needs to specify the
+directory that the executable and the license key are in (must be in the same directory).
+This can be done by adding the ``RELAP5_DIR`` variable to the environment or by 
+explicitly specifying the path in the Python script as::
+
+    relap5_plugin.relap5_dir = "\path\to\executable\and\license"
+
+The RELAP5 executable is OS-dependent. It defaults to ``relap5.x`` (assumed to be
+present on your :envvar:`PATH`) for Linux and macOS, and ``relap5.exe`` for
+Windows.
+
+The plugin also supports extra input options to RELAP5-3D. User simply needs to add the
+extra options as a string to the ``extra_option`` argument when instantiating the plugin as follows::
+
+    relap5_plugin = watts.PluginRELAP5('relap5_template', 
+                                        extra_options = ['-w', 'tpfh2o', '-e', 'tpfn2', '-tpfdir', 'location\of\fluid\property\files']) 
+
+Note that the fluid property files can be specified as extra input options, as shown above. Another
+approach is simply put them in the same directory as the executable and license key before running the plugin.
+
+For the postprocessing of RELAP5-3D results, the plugin converts the default "plotfl" plot file generated
+by RELAP5-3D into a ".CSV" file. Card-104 must be specified as "ascii" in the RELAP5-3D input file as::
+
+    104          ascii
+
+to ensure that the "plotfl" is in ASCII format instead of the default binary format. As the conversion 
+process could be computationally expensive, user can turn it off by omitting Card-104 in the RELAP5-3D input 
+file and adding ``plotfl_to_csv=False`` when instantiating the plugin as follows::
+
+    relap5_plugin = watts.PluginRELAP5('relap5_template', plotfl_to_csv=False)
 
 Results
 +++++++

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -265,12 +265,12 @@ Similar to the SAS executable, the utilities are also OS dependent. To execute
 SAS, the :meth:`~watts.PluginSAS` instance is called directly in the same way as
 other plugins.
 
-SAS4A/SASSY-1 Plugin
+RELAP5-3D Plugin
 ~~~~~~~~~~~~~~~~~~~~
 
-The :class:`~watts.PluginRELAP5` class handles execution of RELAP5-3D. Note that the 
+The :class:`~watts.PluginRELAP5` class handles execution of RELAP5-3D. Note that the
 plugin is designed for the execution of RELAP5-3D v4.3.4 and thus may not be compatible
-with other version of RELAP5-3D. RELAP5-3D uses text-based input files that can be 
+with other version of RELAP5-3D. RELAP5-3D uses text-based input files that can be
 templated as follows:
 
 .. code-block:: jinja
@@ -288,7 +288,7 @@ instantiated with the following command line::
 RELAP5-3D requires the executable, license key, and the input file to be in the same
 directory to run. Thus, before running the RELAP5-3D plugin, user needs to specify the
 directory that the executable and the license key are in (must be in the same directory).
-This can be done by adding the ``RELAP5_DIR`` variable to the environment or by 
+This can be done by adding the ``RELAP5_DIR`` variable to the environment or by
 explicitly specifying the path in the Python script as::
 
     relap5_plugin.relap5_dir = "\path\to\executable\and\license"
@@ -300,8 +300,8 @@ Windows.
 The plugin also supports extra input options to RELAP5-3D. User simply needs to add the
 extra options as a string to the ``extra_option`` argument when instantiating the plugin as follows::
 
-    relap5_plugin = watts.PluginRELAP5('relap5_template', 
-                                        extra_options = ['-w', 'tpfh2o', '-e', 'tpfn2', '-tpfdir', 'location\of\fluid\property\files']) 
+    relap5_plugin = watts.PluginRELAP5('relap5_template',
+                                        extra_options = ['-w', 'tpfh2o', '-e', 'tpfn2', '-tpfdir', 'location\of\fluid\property\files'])
 
 Note that the fluid property files can be specified as extra input options, as shown above. Another
 approach is simply put them in the same directory as the executable and license key before running the plugin.
@@ -311,8 +311,8 @@ by RELAP5-3D into a ".CSV" file. Card-104 must be specified as "ascii" in the RE
 
     104          ascii
 
-to ensure that the "plotfl" is in ASCII format instead of the default binary format. As the conversion 
-process could be computationally expensive, user can turn it off by omitting Card-104 in the RELAP5-3D input 
+to ensure that the "plotfl" is in ASCII format instead of the default binary format. As the conversion
+process could be computationally expensive, user can turn it off by omitting Card-104 in the RELAP5-3D input
 file and adding ``plotfl_to_csv=False`` when instantiating the plugin as follows::
 
     relap5_plugin = watts.PluginRELAP5('relap5_template', plotfl_to_csv=False)

--- a/examples/1App_RELAP5_SingleChannel/README.md
+++ b/examples/1App_RELAP5_SingleChannel/README.md
@@ -5,15 +5,15 @@
 This example provides a demonstration on how to use WATTS to run RELAP5-3D.
 
 ## Code(s)
- 
+
 - RELAP5-3D
 
 ## Keywords
- 
+
 - Single annulus channel
 - Internally heated
 
 ## File descriptions
 
 - [__watts_exec.py__](watts_exec.py): This is the file to execute to run the problem described above.
-- [__relap5_template__](relap5_template): Templated SAS input.
+- [__relap5_template__](relap5_template): Templated RELAP5-3D input.

--- a/examples/1App_RELAP5_SingleChannel/README.md
+++ b/examples/1App_RELAP5_SingleChannel/README.md
@@ -1,0 +1,19 @@
+# 1App_RELAP5_SingleChannel
+
+## Purpose
+
+This example provides a demonstration on how to use WATTS to run RELAP5-3D.
+
+## Code(s)
+ 
+- RELAP5-3D
+
+## Keywords
+ 
+- Single annulus channel
+- Internally heated
+
+## File descriptions
+
+- [__watts_exec.py__](watts_exec.py): This is the file to execute to run the problem described above.
+- [__relap5_template__](relap5_template): Templated SAS input.

--- a/examples/1App_RELAP5_SingleChannel/relap5_template
+++ b/examples/1App_RELAP5_SingleChannel/relap5_template
@@ -1,0 +1,280 @@
+=ANL Water SNGLCHN
+*
+*
+******************************
+*        Model Options       *
+******************************
+*            type         state
+100           new       transnt
+*          option
+101           run
+*          iunits        ounits
+102            si            si
+*
+104          ascii
+*              t1            t2         alloc
+105           1.0           2.0         5.0e5
+*    Noncondensable Gas Species
+110      air
+*            cell          elev         fluid       sysname
+120     910010000           0.0           h2o        SNGLCHN
+*                                                          
+*    tend minstep maxstep copt pfreq  majed rsrtf
+201 200.0 1.0e-10    0.01   19  200   1000  1000
+*
+*******************************
+*       General Tables        *
+*******************************
+*
+*n: HL
+*            type          trip       factor1       factor2
+20240000    htc-t             0           1.0           1.0
+*                 TimeHeat Transfer 
+20240001          -1.0          10.0
+20240001         1.4e5          10.0
+*
+*n: source
+*            type          trip       factor1       factor2
+20250000    power             0           1.0           1.0
+*                 Time         Power
+20250001          -1.0         0.0
+20250002           0.0      {{ heater_power }}
+20250003         1.4e5      {{ heater_power }}
+*
+**************************
+*       Materials        *
+**************************
+*
+*n: SS
+*                 type         tflag         vflag
+20100100      tbl/fctn             1             1
+*                 temp        thcond
+20100101        -100.0         12.97
+20100102         300.0         12.97
+20100103         800.0         21.06
+20100104        1600.0          34.0
+20100105        9999.0          34.0
+*        heat Capacity
+20100151        4.18e6
+*
+*n: KF
+*                 type         tflag         vflag
+20100300      tbl/fctn             1             1
+*                 temp        thcond
+20100301        -100.0        0.0339
+20100302        273.15        0.0339
+20100303        297.15        0.0353
+20100304        305.15        0.0372
+20100305        1000.0        0.0372
+20100306        9999.0        0.0372
+*        heat Capacity
+20100351        8.32e4
+*
+*
+*************************************
+*       Hydraulic Components        *
+*************************************
+*
+************** Pipe ***************
+*                name          type
+2000000       "chan-1"       annulus
+*              ncells
+2000001            10
+*              x-area         volid
+2000101      7.706e-3            10
+*            x-length         volid
+2000301           0.3            10
+*              volume         volid
+2000401           0.0            10
+*          azim-angle         volid
+2000501           0.0            10
+*          vert-angle         volid
+2000601          90.0            10
+*              x-wall           xhd         volid
+2000801           0.0     0.0384302            10
+*             x-flags         volid
+2001001             0            10
+*       ebt   press   temp none none none id
+2001201 003 1.013e5 292.65  0.0  0.0  0.0 10
+*            jefvcahs       jun num
+2001101      00001000             9
+*         jun control
+2001300             1
+*                 mfl           mfv        unused         junid
+2001301           0.0           0.0           0.0             9
+*
+*
+************ Inlet BC *************
+*                name          type
+9100000        "inlet"      tmdpvol
+*                area        length           vol
+9100101        1000.0           0.0        1000.0
+*            az-angle     inc-angle            dz
+9100102           0.0           0.0           0.0
+*             x-rough          x-hd         flags
+9100103           0.0           0.0            10
+*               cword
+9100200             3
+*                srch                  press          temp
+9100201           0.0   {{ inlet_pressure }}        292.65
+*
+*
+************ Outlet BC ************
+*                name          type
+9200000        "outlet"     tmdpvol
+*                area        length           vol
+9200101        1000.0           0.0        1000.0
+*            az-angle     inc-angle            dz
+9200102           0.0           0.0           0.0
+*             x-rough          x-hd         flags
+9200103           0.0           0.0            10
+*               cword
+9200200             2
+*                srch                   press         squal
+9200201           0.0   {{ outlet_pressure }}           1.0
+*
+*
+********** Inlet Junction **********
+*                name          type
+2090000      "inflow"       tmdpjun
+*                from            to          area       jefvcahs
+2090101     910010002     200010001      7.706e-3             0
+*             control          trip         alpha           num
+2090200             1                   
+*                srch           mfl           mfv        unused
+2090201           0.0           0.0           0.0           0.0
+2090202          50.0           0.5           0.0           0.0
+2090203         100.0           0.5           0.0           0.0
+2090204         150.0           0.8           0.0           0.0
+2090205         200.0           0.8           0.0           0.0
+*
+*
+********* Outlet Junction **********
+*                name          type
+2190000     "outflow"       sngljun
+*                from            to          area
+2190101     200100002     920010001      7.706e-3
+*           fwd. loss     rev. loss      jefvcahs
+2190102           1.5           1.5           110
+*           subcooled      twophase
+2190103           1.0           1.0
+*                flow           mfl           mfv        unused
+2190201             1           0.0           0.0           0.0
+*
+*
+********************************
+*       Heat Structures        *
+********************************
+*
+*
+********** Inner Annulus Heater **********
+*          nh   np      geom      ssif     leftcoord reflood
+12000000   10    2         2         1           0.0       0
+*                 mesh        format
+12000100             0             1
+*            intervals        radius
+12000101             1       0.01270
+*             material      interval
+12000201             1             1
+*                 rpkf      interval
+12000301           1.0             1
+*          temp source
+12000400             0
+*                 temp      interval
+12000401        292.65             2
+
+*   Left Boundary Condition Data 
+*            bound      incr      type      code        factor      node
+12000501        0          0         0         1           0.3         1
+12000502        0          0         0         1           0.3         2
+12000503        0          0         0         1           0.3         3
+12000504        0          0         0         1           0.3         4
+12000505        0          0         0         1           0.3         5
+12000506        0          0         0         1           0.3         6
+12000507        0          0         0         1           0.3         7
+12000508        0          0         0         1           0.3         8
+12000509        0          0         0         1           0.3         9
+12000510        0          0         0         1           0.3        10
+
+*   Right Boundary Condition Data 
+*            bound      incr      type      code        factor      node
+12000601 200010000         0       101         1           0.3         1
+12000602 200020000         0       101         1           0.3         2
+12000603 200030000         0       101         1           0.3         3
+12000604 200040000         0       101         1           0.3         4
+12000605 200050000         0       101         1           0.3         5
+12000606 200060000         0       101         1           0.3         6
+12000607 200070000         0       101         1           0.3         7
+12000608 200080000         0       101         1           0.3         8
+12000609 200090000         0       101         1           0.3         9
+12000610 200100000         0       101         1           0.3        10
+*               source          mult          dmhl          dmhr           num
+12000701           500           1.0           0.0           0.0            10
+*   Left Additional Boundary Condition Data 
+12000800             1
+*        hthd  hlf  hlr gslf gslr glcf glcr lbf ncl tpdr foul node
+12000801  0.0 10.0 10.0  0.0  0.0  0.0  0.0 1.0 0.0  1.1  1.0   10
+*   Right Additional Boundary Condition Data 
+12000900             0
+*           hthd  hlf  hlr gslf gslr glcf glcr lbf node
+12000901  0.0127 10.0 10.0  0.0  0.0  0.0  0.0 1.0   10
+*
+*
+********** Outer Channel Wall **********
+*          nh   np      geom      ssif     leftcoord reflood
+12010000   10    9         2         1     0.0511302       0
+*                 mesh        format
+12010100             0             1
+*            intervals        radius
+12010101             4       0.05715
+12010102             4       0.10795
+*             material      interval
+12010201             1             4
+12010202             3             8
+*                 rpkf      interval
+12010301           0.0             8
+*          temp source
+12010400             0
+*                 temp      interval
+12010401        292.65             9
+*
+*   Left Boundary Condition Data 
+*            bound      incr      type      code        factor      node
+12010501 200010000         0       101         1           0.3         1
+12010502 200020000         0       101         1           0.3         2
+12010503 200030000         0       101         1           0.3         3
+12010504 200040000         0       101         1           0.3         4
+12010505 200050000         0       101         1           0.3         5
+12010506 200060000         0       101         1           0.3         6
+12010507 200070000         0       101         1           0.3         7
+12010508 200080000         0       101         1           0.3         8
+12010509 200090000         0       101         1           0.3         9
+12010510 200100000         0       101         1           0.3        10
+*
+*   Right Boundary Condition Data 
+*            bound      incr      type      code        factor      node
+12010601 920010000         0      3400         1           0.3         1
+12010602 920010000         0      3400         1           0.3         2
+12010603 920010000         0      3400         1           0.3         3
+12010604 920010000         0      3400         1           0.3         4
+12010605 920010000         0      3400         1           0.3         5
+12010606 920010000         0      3400         1           0.3         6
+12010607 920010000         0      3400         1           0.3         7
+12010608 920010000         0      3400         1           0.3         8
+12010609 920010000         0      3400         1           0.3         9
+12010610 920010000         0      3400         1           0.3        10
+*               source          mult          dmhl          dmhr           num
+12010701             0           0.0           0.0           0.0            10
+*   Left Additional Boundary Condition Data 
+12010800             1
+*        hthd  hlf  hlr gslf gslr glcf glcr lbf ncl tpdr foul node
+12010801  0.0 10.0 10.0  0.0  0.0  0.0  0.0 1.0 0.0  1.1  1.0   10
+*   Right Additional Boundary Condition Data 
+12010900             0
+*        hthd  hlf  hlr gslf gslr glcf glcr lbf node
+12010901  0.0 10.0 10.0  0.0  0.0  0.0  0.0 1.0   10
+*
+*
+*
+*
+.

--- a/examples/1App_RELAP5_SingleChannel/watts_exec.py
+++ b/examples/1App_RELAP5_SingleChannel/watts_exec.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
+# SPDX-License-Identifier: MIT
+
+"""
+This is an example problem of running RELAP5-3D with WATTS.
+The problem is a single annulus channel where the inner cylinder
+is heated. The inner heater and the outer pipe wall are modeled
+as heat structures. Inlet and outlet boundary conditions are
+specified at the inlet and outlet of the channel. The example
+also shows how to add extra input options to the execution of
+RELAP5-3D.
+"""
+
+import os
+import watts
+from astropy.units import Quantity
+
+from pathlib import Path
+
+params = watts.Parameters()
+
+# Channel params
+params['inlet_pressure'] = 3.0e5
+params['outlet_pressure'] = 1.013e5 
+params['heater_power'] = Quantity(20, "kW")
+
+
+params.show_summary(show_metadata=False, sort_by='key')
+
+# RELAP5-3D Workflow
+relap5_plugin = watts.PluginRELAP5('relap5_template')
+
+# Example of input with extra options, including explicitly specifying the
+# locations of fluid files.
+# relap5_plugin = watts.PluginRELAP5('relap5_template', 
+#                                     extra_options = ['-w', 'tpfh2o', '-e', 'tpfn2', '-tpfdir', 'location\of\fluid\property\files'])
+
+# If RELAP5_DIR is not added to the environment, the directory where the
+# executable and license key are stored can be specified explicitly.
+# relap5_plugin.relap5_dir = "location\of\executable\and\license\key"
+
+relap5_result = relap5_plugin(params)
+for key in relap5_result.csv_data:
+    print(key, relap5_result.csv_data[key])
+print(relap5_result.inputs)
+print(relap5_result.outputs)

--- a/src/watts/__init__.py
+++ b/src/watts/__init__.py
@@ -6,6 +6,7 @@ from .plugin_openmc import *
 from .plugin_moose import *
 from .plugin_pyarc import *
 from .plugin_sas import *
+from .plugin_relap5 import *
 from .template import *
 from .parameters import *
 from .database import *

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
+# SPDX-License-Identifier: MIT
+
+import os
+import glob
+import subprocess
+import platform
+from contextlib import redirect_stdout, redirect_stderr
+from datetime import datetime
+from pathlib import Path
+import shutil
+import time
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+from .fileutils import PathLike, run as run_proc, tee_stdout, tee_stderr
+from .parameters import Parameters
+from .plugin import TemplatePlugin
+from .results import Results
+
+
+class ResultsRELAP5(Results):
+    """RELAP5 simulation results
+
+    Parameters
+    ----------
+    params
+        Parameters used to generate inputs
+    time
+        Time at which workflow was run
+    inputs
+        List of input files
+    outputs
+        List of output files
+
+    Attributes
+    ----------
+    stdout
+        Standard output from RELAP5 run
+    csv_data
+        Dictionary with data from .csv files
+    """
+    def __init__(self, params: Parameters, time: datetime,
+                 inputs: List[PathLike], outputs: List[PathLike]):
+        super().__init__('RELAP5-3D', params, time, inputs, outputs)
+        self.csv_data = self._get_relap5_csv_data()
+
+    @property
+    def stdout(self) -> str:
+        return (self.base_path / "RELAP5_log.txt").read_text()
+
+    def _get_relap5_csv_data(self) -> dict:
+        """Read relap5 '.csv' file and return results in a dictionary
+
+        Returns
+        -------
+        Results from relap5 .csv files
+
+        """
+        csv_data = {}
+        if os.path.exists('R5-out.csv'):
+            csv_file_df = pd.read_csv('R5-out.csv')
+            for column_name in csv_file_df.columns:
+                csv_data[column_name] =  np.array(csv_file_df[column_name])
+        return csv_data
+
+class PluginRELAP5(TemplatePlugin):
+    """Plugin for running RELAP5
+
+    Parameters
+    ----------
+    template_file
+        Templated RELAP5 input
+    show_stdout
+        Whether to display output from stdout when RELAP5 is run
+    show_stderr
+        Whether to display output from stderr when RELAP5 is run
+    plotfl_to_csv
+        Whether to convert RELAP5-3D's plotfl file to CSV file
+    extra_inputs
+        List of extra (non-templated) input files that are needed
+    extra_template_inputs
+        Extra templated input files
+    extra_options
+        Extra options for running RELAP5
+
+    Attributes
+    ----------
+    relap5_dir
+        Path to RELAP5 executable
+
+    """
+
+    def  __init__(self, template_file: str, show_stdout: bool = False,
+                  show_stderr: bool = False, plotfl_to_csv: bool = True,
+                  extra_inputs: Optional[List[str]] = None,
+                  extra_template_inputs: Optional[List[PathLike]] = None,
+                  extra_options: Optional[List[str]] = None):
+        super().__init__(template_file, extra_inputs, extra_template_inputs)
+
+        # Check OS to make sure the extension of the executable is correct.
+        # Linux and macOS have different executables but both are ".x".
+        # The Windows executable is ".exe".
+
+        self._relap5_dir = Path(os.environ.get("RELAP5_DIR", ""))
+        self.ext = "exe" if platform.system() == "Windows" else "x"
+        self._relap5_exec = f"relap5.{self.ext}"
+
+        self.relap5_inp_name = "RELAP5.i"
+        self.show_stdout = show_stdout
+        self.show_stderr = show_stderr
+        self.plotfl_to_csv = plotfl_to_csv
+        self.extra_options = extra_options
+
+    @property
+    def relap5_dir(self) -> Path:
+        return self._relap5_dir
+
+    @relap5_dir.setter
+    def relap5_dir(self, relap5_directory:PathLike):
+        if shutil.which(Path(relap5_directory) / f"relap5.{self.ext}") is None:
+            raise RuntimeError(f"RELAP5-3D executable is missing.")
+        self._relap5_dir = Path(relap5_directory)
+
+    def prerun(self, params: Parameters):
+        """Generate the RELAP5 input based on the template
+
+        Parameters
+        ----------
+        params
+            Parameters used when rendering template
+        """
+        # Render the template
+        # Make a copy of params and convert units if necessary
+        # The original params remains unchanged
+
+        params_copy = params.convert_units()
+
+        print("Pre-run for RELAP5 Plugin")
+        self._run_time = time.time_ns()
+        super().prerun(params_copy, filename=self.relap5_inp_name)
+
+        # Copy all necessary files to the temporary directory.
+        # RELAP5 requires the executable file and the license key 
+        # to be in the same directory as the input file to run.
+        # Users can also add all fluid property files here. 
+
+        files = os.listdir(self._relap5_dir)
+        for fname in files:
+            shutil.copy2(os.path.join(self._relap5_dir, fname), os.getcwd())
+
+        # Create a list for RELAP5 input command and append any extra
+        # options to it.
+
+        self._relap5_input = [self._relap5_exec, '-i', self.relap5_inp_name]
+        if isinstance(self.extra_options, list):
+            for options in self.extra_options:
+                self._relap5_input.append(options) 
+
+    def run(self):
+        """Run RELAP5"""
+
+        print("Run for RELAP5 Plugin")
+
+        log_file = Path("RELAP5_log.txt")
+
+        # run_proc() does not work with RELAP5-3D.
+        # The extra argument of 'stdout' to subprocess.Popen() in run_proc() somehow prevents RELAP5 from running.
+        # As a work-around, we explicitly use subprocess.Popen() here without specifying 'stdout=subprocess.PIPE')
+
+        with log_file.open("w") as outfile:
+            func_stdout = tee_stdout if self.show_stdout else redirect_stdout
+            func_stderr = tee_stderr if self.show_stderr else redirect_stderr
+            with func_stdout(outfile), func_stderr(outfile):
+                p = subprocess.Popen(self._relap5_input)
+                stdout, stderr = p.communicate()
+
+    def postrun(self, params: Parameters) -> ResultsRELAP5:
+        """Read RELAP5 results and create results object
+
+        Parameters
+        ----------
+        params
+            Parameters used to create RELAP5 model
+
+        Returnss
+        -------
+        RELAP5 results object
+        """
+        print("Post-run for RELAP5 Plugin")
+
+        # Convert RELAP5's plotfl file to CSV file for processing
+        if self.plotfl_to_csv:
+            self._plotfl_to_csv()
+
+        time, inputs, outputs = self._get_result_input(self.relap5_inp_name)
+        return ResultsRELAP5(params, time, inputs, outputs)
+
+    # The RELAP5-3D version used here does not generate csv output files.
+    # It generates a text file with a particular format that needs to
+    # be converted to a csv file before the results can be extracted.
+
+    def _plotfl_to_csv(self):
+        """Converts RELAP5's plotfl file to csv.
+
+        """
+
+        with open('plotfl') as f:
+            contents = f.readlines() 
+            
+        # Get markers for 'contents'
+        n_plotinf = self._check_string(contents, 'plotinf')
+        n_plotalf = self._check_string(contents, 'plotalf')
+        n_plotnum = self._check_string(contents, 'plotnum')
+        n_plotrec = self._check_string(contents, 'plotrec')
+
+        # Break 'contents' into 3 sections: channel, ID, values 
+        channels = contents[n_plotalf[0] : n_plotnum[0]]
+        ids = contents[n_plotnum[0] : n_plotrec[0]]
+        values = contents[n_plotrec[0] : ]
+
+        # Extract values
+        channel_list = self._extract_value(channels)
+        id_list = self._extract_value(ids)
+
+        # Create a dictionary to store data
+        data_dict = {'channel': channel_list,
+                'id': id_list}
+
+        for i in range(len(n_plotrec)):
+            i_start = n_plotrec[i] - n_plotrec[0] # Subtract n_plotrec[0] to offset the the 'content' above 'values'
+            i_end = n_plotrec[i] - n_plotrec[0] + (n_plotrec[1] - n_plotrec[0]) # Add "n_plotrec[1] - n_plotrec[0]" to reach the last line of 'values'
+            value_list = np.double(self._extract_value(values[i_start : i_end]))
+            data_dict[f"value_t_{i}"] = value_list
+            
+        # Convert the dictionary into DataFrame
+        df = pd.DataFrame(data_dict)
+        df.set_index('channel', inplace=True)
+        df = df.T
+
+        # Create new column for DataFrame
+        new_col = []
+        for i in range(len(df.columns)):
+            new_col.append(f"{df.columns[i]}-{df.iloc[0][i]}")
+            
+        df.columns = new_col 
+        df = df[1:] # Remove the volume ID row
+
+        # Save DataFrame as csv
+        df.to_csv('R5-out.csv')
+
+    def _check_string(self, file, keyword: str) -> list:
+        """Looks for certain keyword markers in the plotfl file.
+
+        Parameters
+        ----------
+        file
+            RELAP5 output file
+        keyword
+            Keyword whose location to look for
+        Returns
+        -------
+        A list of line number of the keyword markers in the plotfl file
+
+        """
+        n_line = []
+        for i in range(len(file)): 
+            if keyword in file[i]:
+                n_line.append(i)
+        return n_line
+
+    def _extract_value(self, contents):
+        """Extracts values from the plotfl file according to the keyword markers.
+
+        Parameters
+        ----------
+        contents
+            RELAP5 output file broken up according to the keyword markers
+        Returns
+        -------
+        List of extracted values.
+
+        """
+        value_list = []
+        s = ''
+        for line in contents:
+            value_list.append(s.strip())
+            s = ''
+            for char_val in line:
+                if char_val != ' ':
+                    s += str(char_val)
+                else:
+                    value_list.append(s.strip())
+                    s = ''
+        value_list.append(s.strip())           
+        
+        # Remove all spaces
+        while('' in value_list):
+            value_list.remove('')
+        
+        # Remove first element, i.e. markers
+        del value_list[0] 
+        
+        return value_list

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -28,6 +28,8 @@ class ResultsRELAP5(Results):
     ----------
     params
         Parameters used to generate inputs
+    name
+        Name of workflow producing results
     time
         Time at which workflow was run
     inputs
@@ -42,9 +44,9 @@ class ResultsRELAP5(Results):
     csv_data
         Dictionary with data from .csv files
     """
-    def __init__(self, params: Parameters, time: datetime,
+    def __init__(self, params: Parameters, name: str, time: datetime,
                  inputs: List[PathLike], outputs: List[PathLike]):
-        super().__init__('RELAP5-3D', params, time, inputs, outputs)
+        super().__init__('RELAP5-3D', params, name, time, inputs, outputs)
         self.csv_data = self._get_relap5_csv_data()
 
     @property
@@ -177,13 +179,15 @@ class PluginRELAP5(TemplatePlugin):
                 p = subprocess.Popen(self._relap5_input)
                 stdout, stderr = p.communicate()
 
-    def postrun(self, params: Parameters) -> ResultsRELAP5:
+    def postrun(self, params: Parameters, name: str) -> ResultsRELAP5:
         """Read RELAP5 results and create results object
 
         Parameters
         ----------
         params
             Parameters used to create RELAP5 model
+        name
+            Name of the workflow
 
         Returns
         -------
@@ -199,7 +203,7 @@ class PluginRELAP5(TemplatePlugin):
                 raise RuntimeError("Output plot file 'plotfl' is missing. Please make sure you are running the correct version of RELAP5-3D or the plot file is named correctly.")
 
         time, inputs, outputs = self._get_result_input(self.relap5_inp_name)
-        return ResultsRELAP5(params, time, inputs, outputs)
+        return ResultsRELAP5(params, name, time, inputs, outputs)
 
     # The RELAP5-3D version used here does not generate csv output files.
     # It generates a text file with a particular format that needs to

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -121,7 +121,7 @@ class PluginRELAP5(TemplatePlugin):
     @relap5_dir.setter
     def relap5_dir(self, relap5_directory:PathLike):
         if shutil.which(Path(relap5_directory) / f"relap5.{self.ext}") is None:
-            raise RuntimeError(f"RELAP5-3D executable is missing.")
+            raise RuntimeError("RELAP5-3D executable is missing.")
         self._relap5_dir = Path(relap5_directory)
 
     def prerun(self, params: Parameters):
@@ -185,7 +185,7 @@ class PluginRELAP5(TemplatePlugin):
         params
             Parameters used to create RELAP5 model
 
-        Returnss
+        Returns
         -------
         RELAP5 results object
         """
@@ -193,7 +193,10 @@ class PluginRELAP5(TemplatePlugin):
 
         # Convert RELAP5's plotfl file to CSV file for processing
         if self.plotfl_to_csv:
-            self._plotfl_to_csv()
+            if os.path.exists('plotfl'):
+                self._plotfl_to_csv()
+            else:
+                raise RuntimeError("Output plot file 'plotfl' is missing. Please make sure you are running the correct version of RELAP5-3D or the plot file is named correctly.")
 
         time, inputs, outputs = self._get_result_input(self.relap5_inp_name)
         return ResultsRELAP5(params, time, inputs, outputs)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -166,6 +166,7 @@ prop1,prop2
 
 def test_results_relap5(run_in_tmpdir):
     params = watts.Parameters(city='Chicago', population=2.7e6)
+    name = 'SinglePipe'
     now = datetime.now()
 
     # Create some fake input files
@@ -185,11 +186,12 @@ prop1,prop2
     stdout.write_text('RELAP5 standard out\n')
     outputs = [csv, stdout]
 
-    results = watts.ResultsRELAP5(params, now, inputs, outputs)
+    results = watts.ResultsRELAP5(params, name, now, inputs, outputs)
 
     # Sanity checks
     assert results.plugin == 'RELAP5-3D'
     assert results.parameters == params
+    assert results.name == name
     assert results.time == now
     assert results.inputs == inputs
     assert results.outputs == outputs
@@ -208,6 +210,7 @@ prop1,prop2
     new_results = watts.Results.from_pickle(p)
     assert isinstance(new_results, watts.ResultsRELAP5)
     assert new_results.parameters == results.parameters
+    assert new_results.name == results.name
     assert new_results.time == results.time
     assert new_results.inputs == results.inputs
     assert new_results.outputs == results.outputs


### PR DESCRIPTION
A plugin to execute RELAP5-3D with WATTS. Several things to highlight:

- The default `run_proc()` does not work with RELAP5. Seems like it's because of the extra argument of 'stdout' to subprocess.Popen(). As a work around, I explicitly use subprocess.Popen() in the plugin to run the executable.
- This version of RELAP5-3D does not generate a CSV file. Instead, it generates a text file with a specific formatting. The text file needs to be converted to csv before the results can be extracted by the plugin. Other (newer) versions of RELAP5-3D is able to generate output csv files directly. The text-to-csv conversion in the plugin may need to be updated or removed in the future. 
- I also updated the documentation, added an example, and updated the test case for the new plugin.