### PR TITLE
Use uuid for result directory names

### DIFF
--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -24,6 +24,8 @@ class ResultsMOOSE(Results):
     ----------
     params
         Parameters used to generate inputs
+    name
+        Name of workflow producing results
     time
         Time at which workflow was run
     inputs
@@ -38,9 +40,9 @@ class ResultsMOOSE(Results):
     csv_data
         Dictionary with data from .csv files
     """
-    def __init__(self, params: Parameters, time: datetime,
+    def __init__(self, params: Parameters, name: str, time: datetime,
                  inputs: List[PathLike], outputs: List[PathLike]):
-        super().__init__('MOOSE', params, time, inputs, outputs)
+        super().__init__('MOOSE', params, name, time, inputs, outputs)
         self.csv_data = self._save_MOOSE_csv()
 
     @property
@@ -171,13 +173,15 @@ class PluginMOOSE(TemplatePlugin):
                 run_proc(["mpiexec", "-n", str(self.n_cpu), self.moose_exec,
                           "-i", self.moose_inp_name])
 
-    def postrun(self, params: Parameters) -> ResultsMOOSE:
+    def postrun(self, params: Parameters, name: str) -> ResultsMOOSE:
         """Read MOOSE results and create results object
 
         Parameters
         ----------
         params
             Parameters used to create MOOSE model
+        name
+            Name of the workflow
 
         Returns
         -------
@@ -186,4 +190,4 @@ class PluginMOOSE(TemplatePlugin):
         print("Post-run for MOOSE Plugin")
 
         time, inputs, outputs = self._get_result_input(self.moose_inp_name)
-        return ResultsMOOSE(params, time, inputs, outputs)
+        return ResultsMOOSE(params, name, time, inputs, outputs)

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -21,6 +21,8 @@ class ResultsOpenMC(Results):
     ----------
     params
         Parameters used to generate inputs
+    name
+        Name of workflow producing results
     time
         Time at which workflow was run
     inputs
@@ -40,9 +42,9 @@ class ResultsOpenMC(Results):
         List of OpenMC tally objects
     """
 
-    def __init__(self, params: Parameters, time: datetime,
+    def __init__(self, params: Parameters, name: str, time: datetime,
                  inputs: List[Path], outputs: List[Path]):
-        super().__init__('OpenMC', params, time, inputs, outputs)
+        super().__init__('OpenMC', params, name, time, inputs, outputs)
 
     @property
     def statepoints(self) -> List[Path]:
@@ -127,13 +129,15 @@ class PluginOpenMC(Plugin):
             with func_stdout(f), func_stderr(f):
                 openmc.run(**kwargs)
 
-    def postrun(self, params: Parameters) -> ResultsOpenMC:
+    def postrun(self, params: Parameters, name: str) -> ResultsOpenMC:
         """Collect information from OpenMC simulation and create results object
 
         Parameters
         ----------
         params
             Parameters used to create OpenMC model
+        name
+            Name of the workflow
 
         Returns
         -------
@@ -168,4 +172,4 @@ class PluginOpenMC(Plugin):
         outputs.extend(files_since('statepoint.*.h5', self._run_time))
 
         time = datetime.fromtimestamp(self._run_time * 1e-9)
-        return ResultsOpenMC(params, time, inputs, outputs)
+        return ResultsOpenMC(params, name, time, inputs, outputs)

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -23,6 +23,8 @@ class ResultsPyARC(Results):
     ----------
     params
         Parameters used to generate inputs
+    name
+        Name of workflow producing results
     time
         Time at which workflow was run
     inputs
@@ -34,9 +36,9 @@ class ResultsPyARC(Results):
 
     """
 
-    def __init__(self, params: Parameters, time: datetime,
+    def __init__(self, params: Parameters, name: str, time: datetime,
                  inputs: List[Path], outputs: List[Path], results_data: dict):
-        super().__init__('PyARC', params, time, inputs, outputs)
+        super().__init__('PyARC', params, name, time, inputs, outputs)
         self.results_data = results_data
 
     @property
@@ -130,13 +132,15 @@ class PluginPyARC(TemplatePlugin):
         sys.path.pop(0)  # Restore sys.path to original state
         os.chdir(od)  # TODO: I don't know why but I keep going to self._pyarc_exec after execution - this is very wierd!
 
-    def postrun(self, params: Parameters) -> ResultsPyARC:
+    def postrun(self, params: Parameters, name: str) -> ResultsPyARC:
         """Collect information from PyARC and create results object
 
         Parameters
         ----------
         params
             Parameters used to create PyARC model
+        name
+            Name of the workflow
 
         Returns
         -------
@@ -145,4 +149,4 @@ class PluginPyARC(TemplatePlugin):
         print("Post-run for PyARC Plugin")
 
         time, inputs, outputs = self._get_result_input(self.pyarc_inp_name)
-        return ResultsPyARC(params, time, inputs, outputs, self.pyarc.user_object.results)
+        return ResultsPyARC(params, name, time, inputs, outputs, self.pyarc.user_object.results)

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -28,6 +28,8 @@ class ResultsSAS(Results):
     ----------
     params
         Parameters used to generate inputs
+    name
+        Name of workflow producing results
     time
         Time at which workflow was run
     inputs
@@ -42,9 +44,9 @@ class ResultsSAS(Results):
     csv_data
         Dictionary with data from .csv files
     """
-    def __init__(self, params: Parameters, time: datetime,
+    def __init__(self, params: Parameters, name: str, time: datetime,
                  inputs: List[PathLike], outputs: List[PathLike]):
-        super().__init__('SAS', params, time, inputs, outputs)
+        super().__init__('SAS', params, name, time, inputs, outputs)
         self.csv_data = self._get_sas_csv_data()
 
     @property
@@ -172,13 +174,15 @@ class PluginSAS(TemplatePlugin):
             with func_stdout(outfile), func_stderr(outfile):
                 run_proc([self.sas_exec, "-i", self.sas_inp_name, "-o", "out.txt"])
 
-    def postrun(self, params: Parameters) -> ResultsSAS:
+    def postrun(self, params: Parameters, name: str) -> ResultsSAS:
         """Read SAS results and create results object
 
         Parameters
         ----------
         params
             Parameters used to create SAS model
+        name
+            Name of the workflow
 
         Returnss
         -------
@@ -198,4 +202,4 @@ class PluginSAS(TemplatePlugin):
                 subprocess.run(str(self.conv_primar4), stdin=file_in, stdout=file_out)
 
         time, inputs, outputs = self._get_result_input(self.sas_inp_name)
-        return ResultsSAS(params, time, inputs, outputs)
+        return ResultsSAS(params, name, time, inputs, outputs)

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -29,10 +29,11 @@ class Results:
         List of output files
     """
 
-    def __init__(self, plugin: str, params: Parameters, time: datetime,
+    def __init__(self, plugin: str, params: Parameters, name: str, time: datetime,
                  inputs: List[PathLike], outputs: List[PathLike]):
         self.base_path = Path.cwd()
         self.plugin = plugin
+        self.name = name
         self.parameters = Parameters(params)
         self.time = time
         self.inputs = [Path(p) for p in inputs]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -18,6 +18,7 @@ def restore_database_path():
 def get_result():
     return watts.ResultsOpenMC(
         params=watts.Parameters(value=1, lab='Argonne'),
+        name='Workflow',
         time=datetime.now(),
         inputs=['geometry.xml'],
         outputs=['statepoint.50.h5'],

--- a/tests/test_plugin_openmc.py
+++ b/tests/test_plugin_openmc.py
@@ -37,11 +37,12 @@ def test_openmc_plugin():
     assert plugin.model_builder == build_openmc_model
 
     params = watts.Parameters(radius=6.38)
-    result = plugin(params)
+    result = plugin(params, name="OpenMC run")
 
     # Sanity checks
     assert isinstance(result, watts.ResultsOpenMC)
     assert result.parameters['radius'] == 6.38
+    assert result.name == "OpenMC run"
     assert len(result.statepoints) == 5
     input_names = {p.name for p in result.inputs}
     assert input_names == {'geometry.xml', 'materials.xml', 'settings.xml', 'tallies.xml'}
@@ -65,6 +66,7 @@ def test_openmc_plugin():
     db = watts.Database()
     last_result = db[-1]
     assert last_result.parameters['radius'] == result.parameters['radius']
+    assert last_result.name == result.name
     assert last_result.inputs == result.inputs
     assert last_result.outputs == result.outputs
     assert last_result.keff.n == result.keff.n

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -10,6 +10,7 @@ import numpy as np
 
 def test_results_openmc(run_in_tmpdir):
     params = watts.Parameters(city='Chicago', population=2.7e6)
+    name = "🎲"
     now = datetime.now()
 
     # Create some fake input files
@@ -27,11 +28,12 @@ def test_results_openmc(run_in_tmpdir):
     outputs = [sp, log_file]
 
 
-    results = watts.ResultsOpenMC(params, now, inputs, outputs)
+    results = watts.ResultsOpenMC(params, name, now, inputs, outputs)
 
     # Sanity checks
     assert results.plugin == 'OpenMC'
     assert results.parameters == params
+    assert results.name == name
     assert results.time == now
     assert results.inputs == inputs
     assert results.outputs == outputs
@@ -49,6 +51,7 @@ def test_results_openmc(run_in_tmpdir):
     new_results = watts.Results.from_pickle(p)
     assert isinstance(new_results, watts.ResultsOpenMC)
     assert new_results.parameters == results.parameters
+    assert new_results.name == results.name
     assert new_results.time == results.time
     assert new_results.inputs == results.inputs
     assert new_results.outputs == results.outputs
@@ -57,6 +60,7 @@ def test_results_openmc(run_in_tmpdir):
 
 def test_results_moose(run_in_tmpdir):
     params = watts.Parameters(city='Chicago', population=2.7e6)
+    name = "Elk"
     now = datetime.now()
 
     # Create some fake input files
@@ -76,11 +80,12 @@ prop1,prop2
     stdout.write_text('MOOSE standard out\n')
     outputs = [csv, stdout]
 
-    results = watts.ResultsMOOSE(params, now, inputs, outputs)
+    results = watts.ResultsMOOSE(params, name, now, inputs, outputs)
 
     # Sanity checks
     assert results.plugin == 'MOOSE'
     assert results.parameters == params
+    assert results.name == name
     assert results.time == now
     assert results.inputs == inputs
     assert results.outputs == outputs
@@ -99,6 +104,7 @@ prop1,prop2
     new_results = watts.Results.from_pickle(p)
     assert isinstance(new_results, watts.ResultsMOOSE)
     assert new_results.parameters == results.parameters
+    assert new_results.name == results.name
     assert new_results.time == results.time
     assert new_results.inputs == results.inputs
     assert new_results.outputs == results.outputs
@@ -107,6 +113,7 @@ prop1,prop2
 
 def test_results_sas(run_in_tmpdir):
     params = watts.Parameters(city='Chicago', population=2.7e6)
+    name = 'Sassy!'
     now = datetime.now()
 
     # Create some fake input files
@@ -126,11 +133,12 @@ prop1,prop2
     stdout.write_text('SAS standard out\n')
     outputs = [csv, stdout]
 
-    results = watts.ResultsSAS(params, now, inputs, outputs)
+    results = watts.ResultsSAS(params, name, now, inputs, outputs)
 
     # Sanity checks
     assert results.plugin == 'SAS'
     assert results.parameters == params
+    assert results.name == name
     assert results.time == now
     assert results.inputs == inputs
     assert results.outputs == outputs
@@ -149,6 +157,7 @@ prop1,prop2
     new_results = watts.Results.from_pickle(p)
     assert isinstance(new_results, watts.ResultsSAS)
     assert new_results.parameters == results.parameters
+    assert new_results.name == results.name
     assert new_results.time == results.time
     assert new_results.inputs == results.inputs
     assert new_results.outputs == results.outputs


### PR DESCRIPTION
This PR changes the name of the directories used in the database directory. Before, we were generating directory names with sequential integers as "Workflow_#", which potentially causes problems if you have two separate invocations of WATTS running simultaneously (#35). This PR changes it to use Python's `uuid.uuid4` function, which provides a unique identifier that we can use for the directory. In addition, the workflow name is propagated through `postrun` to the `Results` object that is returned.

@nstauff Can you confirm that this fixes #35?