### PR TITLE
Allow PluginOpenMC to use arbitrary function for run()

### DIFF
--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -194,6 +194,20 @@ the plugin are forwarded to the :func:`openmc.run` function. For example::
 
     results = openmc_plugin(params, mpi_args=["mpiexec", "-n", "16"])
 
+By default, the OpenMC plugin will only call the :func:`openmc.run` function,
+but you can customize the execution by passing an arbitrary function as the
+``function`` keyword argument. For example, if you wanted to additionally call
+:func:`openmc.plot_geometry` each time the plugin is called, this could be
+accomplished as follows::
+
+    import openmc
+
+    def run_function():
+        openmc.plot_geometry()
+        openmc.run()
+
+    results = openmc_plugin(params, function=run_function)
+
 PyARC Plugin
 ~~~~~~~~~~~~~
 

--- a/examples/1App_OpenMC_VHTR/watts_exec.py
+++ b/examples/1App_OpenMC_VHTR/watts_exec.py
@@ -67,6 +67,10 @@ print(openmc_result.inputs)
 print(openmc_result.outputs)
 print(openmc_result.tallies[0].get_pandas_dataframe())
 
+# Open folder in order to view plot images that were produced
+openmc_result.open_folder()
+
+# Set power fractions in parameters
 power_fractions = openmc_result.tallies[0].get_values(scores=['nu-fission']).ravel()
 for i, power_frac in enumerate(power_fractions):
     params[f'Init_P_{i+1}'] = power_frac

--- a/examples/1App_OpenMC_VHTR/watts_exec.py
+++ b/examples/1App_OpenMC_VHTR/watts_exec.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 """
-This example demonstrates how to use WATTS to perform 
+This example demonstrates how to use WATTS to perform
 OpenMC calculation. This example uses a simple VHTR unit-cell
 model with 1 coolant channel surrounded by graphite and fuel.
 The demonstration includes the application of unit-conversion
-approach in WATTS. OpenMC is executed and the main results are 
+approach in WATTS. OpenMC is executed and the main results are
 printed out and stored in the params database.
 """
 
@@ -15,6 +15,7 @@ import os
 import watts
 from statistics import mean
 from openmc_template import build_openmc_model
+import openmc
 from astropy.units import Quantity
 
 
@@ -53,9 +54,14 @@ for i in range(1, 6):
 
 params.show_summary(show_metadata=False, sort_by='time')
 
-# Run OpenMC plugin
+# Create OpenMC plugin
 openmc_plugin = watts.PluginOpenMC(build_openmc_model, show_stderr=True) # show only error
-openmc_result = openmc_plugin(params)
+
+# Run OpenMC plugin, instructing it to plot the geometry and run a simulation
+def run_func():
+    openmc.plot_geometry()
+    openmc.run()
+openmc_result = openmc_plugin(params, function=run_func)
 print("KEFF = ", openmc_result.keff)
 print(openmc_result.inputs)
 print(openmc_result.outputs)

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -113,13 +113,16 @@ class PluginOpenMC(Plugin):
         if self.model_builder is not None:
             self.model_builder(params_copy)
 
-    def run(self, **kwargs: Mapping):
+    def run(self, function: Optional[Callable] = None, **kwargs: Mapping):
         """Run OpenMC
 
         Parameters
         ----------
+        function
+            Function to execute. If not passed, defaults to only calling
+            :func:`openmc.run`.
         **kwargs
-            Keyword arguments passed on to :func:`openmc.run`
+            Keyword arguments passed on to ``function``
         """
         print("Run for OpenMC Plugin")
         import openmc
@@ -127,7 +130,10 @@ class PluginOpenMC(Plugin):
             func_stdout = tee_stdout if self.show_stdout else redirect_stdout
             func_stderr = tee_stderr if self.show_stderr else redirect_stderr
             with func_stdout(f), func_stderr(f):
-                openmc.run(**kwargs)
+                if function:
+                    function(**kwargs)
+                else:
+                    openmc.run(**kwargs)
 
     def postrun(self, params: Parameters, name: str) -> ResultsOpenMC:
         """Collect information from OpenMC simulation and create results object
@@ -168,8 +174,11 @@ class PluginOpenMC(Plugin):
         outputs = ['OpenMC_log.txt']
         outputs.extend(files_since('tallies.out', self._run_time))
         outputs.extend(files_since('source.*.h5', self._run_time))
-        outputs.extend(files_since('particle.*.h5', self._run_time))
+        outputs.extend(files_since('particle*.h5', self._run_time))
         outputs.extend(files_since('statepoint.*.h5', self._run_time))
+        outputs.extend(files_since('volume*.h5', self._run_time))
+        outputs.extend(files_since('*.png', self._run_time))
+        outputs.extend(files_since('*.ppm', self._run_time))
 
         time = datetime.fromtimestamp(self._run_time * 1e-9)
         return ResultsOpenMC(params, name, time, inputs, outputs)

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -126,6 +126,11 @@ class PluginOpenMC(Plugin):
             :func:`openmc.run`.
         **kwargs
             Keyword arguments passed on to ``function``
+
+        See also
+        --------
+        openmc.run, openmc.plot_geometry, openmc.calculate_volumes
+
         """
         print("Run for OpenMC Plugin")
         import openmc

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -57,7 +57,10 @@ class ResultsOpenMC(Results):
         # Get k-effective from last statepoint
         last_statepoint = self.statepoints[-1]
         with openmc.StatePoint(last_statepoint) as sp:
-            return sp.k_combined
+            if hasattr(sp, 'keff'):
+                return sp.keff
+            else:
+                return sp.k_combined
 
     @property
     @lru_cache()


### PR DESCRIPTION
This PR enhances `PluginOpenMC` to allow a user-customized run function (satisfying the intent of #34). I had considered originally having additional arguments for volume calculation / geometry plotting, something like:
```Python
def run(self, calculate_volumes=False, plot_geometry=False, ...):
    ...
```
However, once I started down that path, I realized that it's not clear how the optional keyword arguments should be handled. Should they be passed to all functions (`run`, `plot_geometry`, and `calculate_volumes`) or only one of them? Some arguments make sense for all (`mpi_args` for example), but others are more specific (e.g., `restart_file` only makes sense to be passed to `run`).

Instead of that approach, I went for something a little more flexible — the user can pass an arbitrary function that has whatever logic they wish to run. I've added an example in the user's guide demonstrating how you could call both `plot_geometry` and `run`.