### PR TITLE
Move some logic in plugins to base Plugin class to avoid duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* RELAP-5 Plugin
+
 ### Changes
 
 * The `Plugin.__call__` method now allows arbitrary keyword arguments to be
   passed on to the `Plugin.run` method
 * The `Database` class now acts like a sequence
+* Database directory names use random strings to avoid clashes when multiple
+  instances of WATTS are running simulataneously
+* File template-based plugins now accept an `extra_template_inputs` argument
+  indicating extra template files that should be rendered
+* The `PluginOpenMC` class now takes an optional `function` argument that
+  specifies an arbitrary execution sequence
 
 ## [0.2.0]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = watts
-version = 0.2.0
+version = 0.3.0-dev
 author = UChicago Argonne, LLC
 author_email = watts@anl.gov
 description = Workflow and Template Toolkit for Simulation

--- a/src/watts/__init__.py
+++ b/src/watts/__init__.py
@@ -14,4 +14,4 @@ from .database import *
 # This allows a user to write watts.Quantity
 from astropy.units import Quantity
 
-__version__ = '0.2.0'
+__version__ = '0.3.0-dev'

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import uuid
 from pathlib import Path
 import shutil
+import time
 from typing import Optional, List
 
 from .database import Database
@@ -85,6 +86,7 @@ class Plugin(ABC):
                 shutil.copy(str(path), str(cwd))  # Remove str() for Python 3.8+
 
             # Generate input files and perform any other prerun actions
+            self._run_time = time.time_ns()
             print(f"[watts] Calling prerun() for {plugin_name} Plugin")
             self.prerun(params)
 

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -76,6 +76,7 @@ class Plugin(ABC):
         Results from running workflow
         """
         db = Database()
+        plugin_name = self.plugin_name
 
         with cd_tmpdir():
             # Copy extra inputs to temporary directory
@@ -84,16 +85,19 @@ class Plugin(ABC):
                 shutil.copy(str(path), str(cwd))  # Remove str() for Python 3.8+
 
             # Generate input files and perform any other prerun actions
+            print(f"[watts] Calling prerun() for {plugin_name} Plugin")
             self.prerun(params)
 
             # Execute the code, redirecting stdout/stderr if requested
-            with open(f'{self.plugin_name}_log.txt', 'w') as outfile:
+            print(f"[watts] Calling run() for {plugin_name} Plugin")
+            with open(f'{plugin_name}_log.txt', 'w') as outfile:
                 func_stdout = tee_stdout if self.show_stdout else redirect_stdout
                 func_stderr = tee_stderr if self.show_stderr else redirect_stderr
                 with func_stdout(outfile), func_stderr(outfile):
                     self.run(**kwargs)
 
             # Collect results and perform any postrun actions
+            print(f"[watts] Calling postrun() for {plugin_name} Plugin")
             result = self.postrun(params, name)
 
             # Create new directory for results and move files there

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -60,7 +60,7 @@ class Plugin(ABC):
     def plugin_name(self):
         return type(self).__name__[6:]
 
-    def __call__(self, params: Parameters, name: str = 'Workflow', **kwargs) -> Results:
+    def __call__(self, params: Parameters = None, name: str = 'Workflow', **kwargs) -> Results:
         """Run the complete workflow for the plugin
 
         Parameters
@@ -78,6 +78,10 @@ class Plugin(ABC):
         """
         db = Database()
         plugin_name = self.plugin_name
+
+        # Generate empty Parameters object if none provided
+        if params is None:
+            params = Parameters()
 
         with cd_tmpdir():
             # Copy extra inputs to temporary directory

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -4,7 +4,6 @@
 from datetime import datetime
 from pathlib import Path
 import shutil
-import time
 from typing import List, Optional
 
 import numpy as np
@@ -153,8 +152,6 @@ class PluginMOOSE(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-
-        self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.moose_inp_name)
 
     def run(self):

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -154,13 +154,11 @@ class PluginMOOSE(TemplatePlugin):
 
         params_copy = params.convert_units()
 
-        print("Pre-run for MOOSE Plugin")
         self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.moose_inp_name)
 
     def run(self):
         """Run MOOSE"""
-        print("Run for MOOSE Plugin")
         run_proc(["mpiexec", "-n", str(self.n_cpu), self.moose_exec,
                     "-i", self.moose_inp_name])
 
@@ -178,7 +176,6 @@ class PluginMOOSE(TemplatePlugin):
         -------
         MOOSE results object
         """
-        print("Post-run for MOOSE Plugin")
 
         time, inputs, outputs = self._get_result_input(self.moose_inp_name)
         return ResultsMOOSE(params, name, time, inputs, outputs)

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -139,21 +139,6 @@ class PluginMOOSE(TemplatePlugin):
         """
         self.moose_exec = moose_exec
 
-    def prerun(self, params: Parameters):
-        """Generate the MOOSE input based on the template
-
-        Parameters
-        ----------
-        params
-            Parameters used when rendering template
-        """
-        # Render the template
-        # Make a copy of params and convert units if necessary
-        # The original params remains unchanged
-
-        params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.input_name)
-
     def run(self):
         """Run MOOSE"""
         run_proc(["mpiexec", "-n", str(self.n_cpu), self.moose_exec,

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -114,7 +114,7 @@ class PluginMOOSE(TemplatePlugin):
         super().__init__(template_file, extra_inputs, extra_template_inputs,
                          show_stdout, show_stderr)
         self._moose_exec = Path('moose-opt')
-        self.moose_inp_name = "MOOSE.i"
+        self.input_name = "MOOSE.i"
         if n_cpu < 1:
             raise RuntimeError("The CPU number used to run MOOSE app must be a natural number.")
         self.n_cpu = n_cpu
@@ -152,12 +152,12 @@ class PluginMOOSE(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.moose_inp_name)
+        super().prerun(params_copy, filename=self.input_name)
 
     def run(self):
         """Run MOOSE"""
         run_proc(["mpiexec", "-n", str(self.n_cpu), self.moose_exec,
-                    "-i", self.moose_inp_name])
+                    "-i", self.input_name])
 
     def postrun(self, params: Parameters, name: str) -> ResultsMOOSE:
         """Read MOOSE results and create results object
@@ -174,5 +174,5 @@ class PluginMOOSE(TemplatePlugin):
         MOOSE results object
         """
 
-        time, inputs, outputs = self._get_result_input(self.moose_inp_name)
+        time, inputs, outputs = self._get_result_input(self.input_name)
         return ResultsMOOSE(params, name, time, inputs, outputs)

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -95,6 +95,7 @@ class PluginOpenMC(Plugin):
                  show_stdout: bool = False, show_stderr: bool = False):
         super().__init__(extra_inputs, show_stdout, show_stderr)
         self.model_builder = model_builder
+        self.unit_system = 'cgs'
 
     def prerun(self, params: Parameters) -> None:
         """Generate OpenMC input files
@@ -105,7 +106,7 @@ class PluginOpenMC(Plugin):
             Parameters used by the OpenMC template
         """
         # Convert quantities in parameters to CGS system
-        params_copy = params.convert_units(system='cgs')
+        params_copy = params.convert_units(system=self.unit_system)
 
         if self.model_builder is not None:
             self.model_builder(params_copy)

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
 # SPDX-License-Identifier: MIT
 
-from contextlib import redirect_stdout, redirect_stderr
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 import time
 from typing import Callable, Mapping, List, Optional
 
-from .fileutils import PathLike, tee_stdout, tee_stderr
+from .fileutils import PathLike
 from .parameters import Parameters
 from .plugin import Plugin
 from .results import Results
@@ -95,10 +94,8 @@ class PluginOpenMC(Plugin):
     def __init__(self, model_builder: Optional[Callable[[Parameters], None]] = None,
                  extra_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        super().__init__(extra_inputs)
+        super().__init__(extra_inputs, show_stdout, show_stderr)
         self.model_builder = model_builder
-        self.show_stdout = show_stdout
-        self.show_stderr = show_stderr
 
     def prerun(self, params: Parameters) -> None:
         """Generate OpenMC input files
@@ -134,14 +131,10 @@ class PluginOpenMC(Plugin):
         """
         print("Run for OpenMC Plugin")
         import openmc
-        with open('OpenMC_log.txt', 'w') as f:
-            func_stdout = tee_stdout if self.show_stdout else redirect_stdout
-            func_stderr = tee_stderr if self.show_stderr else redirect_stderr
-            with func_stdout(f), func_stderr(f):
-                if function:
-                    function(**kwargs)
-                else:
-                    openmc.run(**kwargs)
+        if function:
+            function(**kwargs)
+        else:
+            openmc.run(**kwargs)
 
     def postrun(self, params: Parameters, name: str) -> ResultsOpenMC:
         """Collect information from OpenMC simulation and create results object

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -108,7 +108,6 @@ class PluginOpenMC(Plugin):
         # Convert quantities in parameters to CGS system
         params_copy = params.convert_units(system='cgs')
 
-        print("Pre-run for OpenMC Plugin")
         self._run_time = time.time_ns()
         if self.model_builder is not None:
             self.model_builder(params_copy)
@@ -129,7 +128,6 @@ class PluginOpenMC(Plugin):
         openmc.run, openmc.plot_geometry, openmc.calculate_volumes
 
         """
-        print("Run for OpenMC Plugin")
         import openmc
         if function:
             function(**kwargs)
@@ -150,7 +148,6 @@ class PluginOpenMC(Plugin):
         -------
         OpenMC results object
         """
-        print("Post-run for OpenMC Plugin")
 
         def files_since(pattern, time):
             matches = []

--- a/src/watts/plugin_openmc.py
+++ b/src/watts/plugin_openmc.py
@@ -4,7 +4,6 @@
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-import time
 from typing import Callable, Mapping, List, Optional
 
 from .fileutils import PathLike
@@ -108,7 +107,6 @@ class PluginOpenMC(Plugin):
         # Convert quantities in parameters to CGS system
         params_copy = params.convert_units(system='cgs')
 
-        self._run_time = time.time_ns()
         if self.model_builder is not None:
             self.model_builder(params_copy)
 

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -86,21 +86,6 @@ class PluginPyARC(TemplatePlugin):
             raise RuntimeError(f"PyARC executable '{exe}' is missing.")
         self._pyarc_exec = Path(exe)
 
-    def prerun(self, params: Parameters) -> None:
-        """Generate PyARC input files
-
-        Parameters
-        ----------
-        params
-            Parameters used by the PyARC template
-        """
-        # Render the template
-        # Make a copy of params and convert units if necessary
-        # The original params remains unchanged
-
-        params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.input_name)
-
     def run(self, **kwargs: Mapping):
         """Run PyARC
 

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import os
 import sys
 import tempfile
-import time
 from typing import Mapping, List, Optional
 
 from .fileutils import PathLike
@@ -100,8 +99,6 @@ class PluginPyARC(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-
-        self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.pyarc_inp_name)
 
     def run(self, **kwargs: Mapping):

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -101,7 +101,6 @@ class PluginPyARC(TemplatePlugin):
 
         params_copy = params.convert_units()
 
-        print("Pre-run for PyARC Plugin")
         self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.pyarc_inp_name)
 
@@ -113,7 +112,6 @@ class PluginPyARC(TemplatePlugin):
         **kwargs
             Keyword arguments passed on to :func:`pyarc.execute`
         """
-        print("Run for PyARC Plugin")
         sys.path.insert(0, f'{self._pyarc_exec}')
         import PyARC
         self.pyarc = PyARC.PyARC()
@@ -140,7 +138,6 @@ class PluginPyARC(TemplatePlugin):
         -------
         PyARC results object
         """
-        print("Post-run for PyARC Plugin")
 
         time, inputs, outputs = self._get_result_input(self.pyarc_inp_name)
         return ResultsPyARC(params, name, time, inputs, outputs, self.pyarc.user_object.results)

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -74,7 +74,7 @@ class PluginPyARC(TemplatePlugin):
         super().__init__(template_file, extra_inputs, extra_template_inputs,
                          show_stdout, show_stderr)
         self._pyarc_exec = Path(os.environ.get('PyARC_DIR', 'PyARC.py'))
-        self.pyarc_inp_name = "pyarc_input.son"
+        self.input_name = "pyarc_input.son"
 
     @property
     def pyarc_exec(self) -> Path:
@@ -99,7 +99,7 @@ class PluginPyARC(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.pyarc_inp_name)
+        super().prerun(params_copy, filename=self.input_name)
 
     def run(self, **kwargs: Mapping):
         """Run PyARC
@@ -117,7 +117,7 @@ class PluginPyARC(TemplatePlugin):
         od = Path.cwd()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            self.pyarc.execute(["-i", self.pyarc_inp_name, "-w", tmpdir, "-o", str(od)], **kwargs)
+            self.pyarc.execute(["-i", self.input_name, "-w", tmpdir, "-o", str(od)], **kwargs)
         sys.path.pop(0)  # Restore sys.path to original state
         os.chdir(od)  # TODO: I don't know why but I keep going to self._pyarc_exec after execution - this is very wierd!
 
@@ -136,5 +136,5 @@ class PluginPyARC(TemplatePlugin):
         PyARC results object
         """
 
-        time, inputs, outputs = self._get_result_input(self.pyarc_inp_name)
+        time, inputs, outputs = self._get_result_input(self.input_name)
         return ResultsPyARC(params, name, time, inputs, outputs, self.pyarc.user_object.results)

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -130,12 +130,7 @@ class PluginRELAP5(TemplatePlugin):
         params
             Parameters used when rendering template
         """
-        # Render the template
-        # Make a copy of params and convert units if necessary
-        # The original params remains unchanged
-
-        params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.input_name)
+        super().prerun(params)
 
         # Copy all necessary files to the temporary directory.
         # RELAP5 requires the executable file and the license key

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -137,7 +137,6 @@ class PluginRELAP5(TemplatePlugin):
 
         params_copy = params.convert_units()
 
-        print("Pre-run for RELAP5 Plugin")
         self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.relap5_inp_name)
 
@@ -161,8 +160,6 @@ class PluginRELAP5(TemplatePlugin):
     def run(self):
         """Run RELAP5"""
 
-        print("Run for RELAP5 Plugin")
-
         # run_proc() does not work with RELAP5-3D.
         # The extra argument of 'stdout' to subprocess.Popen() in run_proc() somehow prevents RELAP5 from running.
         # As a work-around, we explicitly use subprocess.Popen() here without specifying 'stdout=subprocess.PIPE')
@@ -183,7 +180,6 @@ class PluginRELAP5(TemplatePlugin):
         -------
         RELAP5 results object
         """
-        print("Post-run for RELAP5 Plugin")
 
         # Convert RELAP5's plotfl file to CSV file for processing
         if self.plotfl_to_csv:

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -108,7 +108,7 @@ class PluginRELAP5(TemplatePlugin):
         self.ext = "exe" if platform.system() == "Windows" else "x"
         self._relap5_exec = f"relap5.{self.ext}"
 
-        self.relap5_inp_name = "RELAP5.i"
+        self.input_name = "RELAP5.i"
         self.plotfl_to_csv = plotfl_to_csv
         self.extra_options = extra_options
 
@@ -135,7 +135,7 @@ class PluginRELAP5(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.relap5_inp_name)
+        super().prerun(params_copy, filename=self.input_name)
 
         # Copy all necessary files to the temporary directory.
         # RELAP5 requires the executable file and the license key
@@ -149,7 +149,7 @@ class PluginRELAP5(TemplatePlugin):
         # Create a list for RELAP5 input command and append any extra
         # options to it.
 
-        self._relap5_input = [self._relap5_exec, '-i', self.relap5_inp_name]
+        self._relap5_input = [self._relap5_exec, '-i', self.input_name]
         if isinstance(self.extra_options, list):
             for options in self.extra_options:
                 self._relap5_input.append(options)
@@ -185,7 +185,7 @@ class PluginRELAP5(TemplatePlugin):
             else:
                 raise RuntimeError("Output plot file 'plotfl' is missing. Please make sure you are running the correct version of RELAP5-3D or the plot file is named correctly.")
 
-        time, inputs, outputs = self._get_result_input(self.relap5_inp_name)
+        time, inputs, outputs = self._get_result_input(self.input_name)
         return ResultsRELAP5(params, name, time, inputs, outputs)
 
     # The RELAP5-3D version used here does not generate csv output files.

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -7,7 +7,6 @@ import platform
 from datetime import datetime
 from pathlib import Path
 import shutil
-import time
 from typing import List, Optional
 
 import numpy as np
@@ -136,8 +135,6 @@ class PluginRELAP5(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-
-        self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.relap5_inp_name)
 
         # Copy all necessary files to the temporary directory.

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 import os
-import glob
 import subprocess
 import platform
-from contextlib import redirect_stdout, redirect_stderr
 from datetime import datetime
 from pathlib import Path
 import shutil
@@ -15,7 +13,7 @@ from typing import List, Optional
 import numpy as np
 import pandas as pd
 
-from .fileutils import PathLike, run as run_proc, tee_stdout, tee_stderr
+from .fileutils import PathLike
 from .parameters import Parameters
 from .plugin import TemplatePlugin
 from .results import Results
@@ -75,10 +73,6 @@ class PluginRELAP5(TemplatePlugin):
     ----------
     template_file
         Templated RELAP5 input
-    show_stdout
-        Whether to display output from stdout when RELAP5 is run
-    show_stderr
-        Whether to display output from stderr when RELAP5 is run
     plotfl_to_csv
         Whether to convert RELAP5-3D's plotfl file to CSV file
     extra_inputs
@@ -87,6 +81,10 @@ class PluginRELAP5(TemplatePlugin):
         Extra templated input files
     extra_options
         Extra options for running RELAP5
+    show_stdout
+        Whether to display output from stdout when RELAP5 is run
+    show_stderr
+        Whether to display output from stderr when RELAP5 is run
 
     Attributes
     ----------
@@ -95,12 +93,13 @@ class PluginRELAP5(TemplatePlugin):
 
     """
 
-    def  __init__(self, template_file: str, show_stdout: bool = False,
-                  show_stderr: bool = False, plotfl_to_csv: bool = True,
+    def  __init__(self, template_file: str, plotfl_to_csv: bool = True,
                   extra_inputs: Optional[List[str]] = None,
                   extra_template_inputs: Optional[List[PathLike]] = None,
-                  extra_options: Optional[List[str]] = None):
-        super().__init__(template_file, extra_inputs, extra_template_inputs)
+                  extra_options: Optional[List[str]] = None,
+                  show_stdout: bool = False, show_stderr: bool = False):
+        super().__init__(template_file, extra_inputs, extra_template_inputs,
+                         show_stdout, show_stderr)
 
         # Check OS to make sure the extension of the executable is correct.
         # Linux and macOS have different executables but both are ".x".
@@ -111,8 +110,6 @@ class PluginRELAP5(TemplatePlugin):
         self._relap5_exec = f"relap5.{self.ext}"
 
         self.relap5_inp_name = "RELAP5.i"
-        self.show_stdout = show_stdout
-        self.show_stderr = show_stderr
         self.plotfl_to_csv = plotfl_to_csv
         self.extra_options = extra_options
 
@@ -145,9 +142,9 @@ class PluginRELAP5(TemplatePlugin):
         super().prerun(params_copy, filename=self.relap5_inp_name)
 
         # Copy all necessary files to the temporary directory.
-        # RELAP5 requires the executable file and the license key 
+        # RELAP5 requires the executable file and the license key
         # to be in the same directory as the input file to run.
-        # Users can also add all fluid property files here. 
+        # Users can also add all fluid property files here.
 
         files = os.listdir(self._relap5_dir)
         for fname in files:
@@ -159,25 +156,18 @@ class PluginRELAP5(TemplatePlugin):
         self._relap5_input = [self._relap5_exec, '-i', self.relap5_inp_name]
         if isinstance(self.extra_options, list):
             for options in self.extra_options:
-                self._relap5_input.append(options) 
+                self._relap5_input.append(options)
 
     def run(self):
         """Run RELAP5"""
 
         print("Run for RELAP5 Plugin")
 
-        log_file = Path("RELAP5_log.txt")
-
         # run_proc() does not work with RELAP5-3D.
         # The extra argument of 'stdout' to subprocess.Popen() in run_proc() somehow prevents RELAP5 from running.
         # As a work-around, we explicitly use subprocess.Popen() here without specifying 'stdout=subprocess.PIPE')
-
-        with log_file.open("w") as outfile:
-            func_stdout = tee_stdout if self.show_stdout else redirect_stdout
-            func_stderr = tee_stderr if self.show_stderr else redirect_stderr
-            with func_stdout(outfile), func_stderr(outfile):
-                p = subprocess.Popen(self._relap5_input)
-                stdout, stderr = p.communicate()
+        p = subprocess.Popen(self._relap5_input)
+        stdout, stderr = p.communicate()
 
     def postrun(self, params: Parameters, name: str) -> ResultsRELAP5:
         """Read RELAP5 results and create results object
@@ -215,15 +205,15 @@ class PluginRELAP5(TemplatePlugin):
         """
 
         with open('plotfl') as f:
-            contents = f.readlines() 
-            
+            contents = f.readlines()
+
         # Get markers for 'contents'
         n_plotinf = self._check_string(contents, 'plotinf')
         n_plotalf = self._check_string(contents, 'plotalf')
         n_plotnum = self._check_string(contents, 'plotnum')
         n_plotrec = self._check_string(contents, 'plotrec')
 
-        # Break 'contents' into 3 sections: channel, ID, values 
+        # Break 'contents' into 3 sections: channel, ID, values
         channels = contents[n_plotalf[0] : n_plotnum[0]]
         ids = contents[n_plotnum[0] : n_plotrec[0]]
         values = contents[n_plotrec[0] : ]
@@ -241,7 +231,7 @@ class PluginRELAP5(TemplatePlugin):
             i_end = n_plotrec[i] - n_plotrec[0] + (n_plotrec[1] - n_plotrec[0]) # Add "n_plotrec[1] - n_plotrec[0]" to reach the last line of 'values'
             value_list = np.double(self._extract_value(values[i_start : i_end]))
             data_dict[f"value_t_{i}"] = value_list
-            
+
         # Convert the dictionary into DataFrame
         df = pd.DataFrame(data_dict)
         df.set_index('channel', inplace=True)
@@ -251,8 +241,8 @@ class PluginRELAP5(TemplatePlugin):
         new_col = []
         for i in range(len(df.columns)):
             new_col.append(f"{df.columns[i]}-{df.iloc[0][i]}")
-            
-        df.columns = new_col 
+
+        df.columns = new_col
         df = df[1:] # Remove the volume ID row
 
         # Save DataFrame as csv
@@ -273,7 +263,7 @@ class PluginRELAP5(TemplatePlugin):
 
         """
         n_line = []
-        for i in range(len(file)): 
+        for i in range(len(file)):
             if keyword in file[i]:
                 n_line.append(i)
         return n_line
@@ -301,13 +291,13 @@ class PluginRELAP5(TemplatePlugin):
                 else:
                     value_list.append(s.strip())
                     s = ''
-        value_list.append(s.strip())           
-        
+        value_list.append(s.strip())
+
         # Remove all spaces
         while('' in value_list):
             value_list.remove('')
-        
+
         # Remove first element, i.e. markers
-        del value_list[0] 
-        
+        del value_list[0]
+
         return value_list

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -109,7 +109,7 @@ class PluginSAS(TemplatePlugin):
         self._conv_channel = sas_dir / f"CHANNELtoCSV.{ext}"
         self._conv_primar4 = sas_dir / f"PRIMAR4toCSV.{ext}"
 
-        self.sas_inp_name = "SAS.inp"
+        self.input_name = "SAS.inp"
 
     @property
     def sas_exec(self) -> Path:
@@ -154,11 +154,11 @@ class PluginSAS(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.sas_inp_name)
+        super().prerun(params_copy, filename=self.input_name)
 
     def run(self):
         """Run SAS"""
-        run_proc([self.sas_exec, "-i", self.sas_inp_name, "-o", "out.txt"])
+        run_proc([self.sas_exec, "-i", self.input_name, "-o", "out.txt"])
 
     def postrun(self, params: Parameters, name: str) -> ResultsSAS:
         """Read SAS results and create results object
@@ -186,5 +186,5 @@ class PluginSAS(TemplatePlugin):
             with open("PRIMAR4.dat", "r") as file_in, open("PRIMAR4.csv", "w") as file_out:
                 subprocess.run(str(self.conv_primar4), stdin=file_in, stdout=file_out)
 
-        time, inputs, outputs = self._get_result_input(self.sas_inp_name)
+        time, inputs, outputs = self._get_result_input(self.input_name)
         return ResultsSAS(params, name, time, inputs, outputs)

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -141,21 +141,6 @@ class PluginSAS(TemplatePlugin):
             raise RuntimeError(f"PRIMAR4toCSV utility executable '{exe}' is missing.")
         self._conv_primar4 = Path(exe)
 
-    def prerun(self, params: Parameters):
-        """Generate the SAS input based on the template
-
-        Parameters
-        ----------
-        params
-            Parameters used when rendering template
-        """
-        # Render the template
-        # Make a copy of params and convert units if necessary
-        # The original params remains unchanged
-
-        params_copy = params.convert_units()
-        super().prerun(params_copy, filename=self.input_name)
-
     def run(self):
         """Run SAS"""
         run_proc([self.sas_exec, "-i", self.input_name, "-o", "out.txt"])

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -8,7 +8,6 @@ import platform
 from datetime import datetime
 from pathlib import Path
 import shutil
-import time
 from typing import List, Optional
 
 import numpy as np
@@ -155,8 +154,6 @@ class PluginSAS(TemplatePlugin):
         # The original params remains unchanged
 
         params_copy = params.convert_units()
-
-        self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.sas_inp_name)
 
     def run(self):

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -156,13 +156,11 @@ class PluginSAS(TemplatePlugin):
 
         params_copy = params.convert_units()
 
-        print("Pre-run for SAS Plugin")
         self._run_time = time.time_ns()
         super().prerun(params_copy, filename=self.sas_inp_name)
 
     def run(self):
         """Run SAS"""
-        print("Run for SAS Plugin")
         run_proc([self.sas_exec, "-i", self.sas_inp_name, "-o", "out.txt"])
 
     def postrun(self, params: Parameters, name: str) -> ResultsSAS:
@@ -179,7 +177,6 @@ class PluginSAS(TemplatePlugin):
         -------
         SAS results object
         """
-        print("Post-run for SAS Plugin")
 
         # Convert CHANNEl.dat and PRIMER4.dat to csv files
         # using SAS utilities. Check if files exist because


### PR DESCRIPTION
This PR makes some simplifications in each of the concrete Plugin classes by:
- Moving the logic for redirection of stdout/stderr to the base `Plugin` class
- Also move the `print()` statements for prerun, run, and postrun to the base `Plugin` class

I've also updated the CHANGELOG, which was missing updates from previous PRs.