### PR TITLE
changes p.stdout.read to communicate()

### DIFF
--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -84,7 +84,7 @@ class tee_stderr(_TeeStream):
     _stream = "stderr"
 
 
-def run(args, wait):
+def run(args, wait=None):
     """Function that mimics subprocess.run but actually writes to sys.stdout and
     sys.stderr (not the same as the underlying file descriptors)
 

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -102,6 +102,8 @@ def run(args, wait=None):
         p.kill()
         stdout_data, stderr_data = p.communicate()
 
-    sys.stdout.write(stdout_data)
+    if stdout_data:
+        sys.stdout.write(stdout_data)
 
-    sys.stderr.write(stderr_data)
+    if stderr_data:
+        sys.stderr.write(stderr_data)

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -223,7 +223,8 @@ class TemplatePlugin(Plugin):
         return results_cls(params, name, time, inputs, outputs, **kwargs)
 
     def run(self, mpi_args: Optional[List[str]] = None,
-            extra_args: Optional[List[str]] = None):
+            extra_args: Optional[List[str]] = None, 
+            wait: Optional[int] = 60):
         """Run plugin
 
         Parameters
@@ -234,9 +235,13 @@ class TemplatePlugin(Plugin):
         extra_args
             Additional command-line arguments to append after the main command
 
+        wait 
+            The time in seconds that `watts` will wait before terminating the process.
+            Default is 60 seconds.
+
         """
         if mpi_args is None:
             mpi_args = []
         if extra_args is None:
             extra_args = []
-        run_proc(mpi_args + self.execute_command + extra_args)
+        run_proc(mpi_args + self.execute_command + extra_args, wait)


### PR DESCRIPTION
This PR closes #49 by updating `fileutils.run()` with `subprocess.Popen.communicate()` rather than `Popen.stdout.read()` (and similar). 

Currently, `watts` runs external programs by creating a child process with the `subprocess` package and read/writes the output to the terminal (and a temporary log file) using `subprocess.Popen.stdout.read()` and `.write()`. According to the `subprocess` docs, this can result in a [deadlock](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate). The safer approach is to use `communicate()` instead.

As explained in #49 this issue was discovered because `watts` deadlocked anytime it ran the `abce` code. The fix in this PR seems to preserve the intended usage of `watts` after some ad hoc test runs with `abce`. However, there are still some issues with `abce` itself, and since `abce` is the only code I have access to (within the `watts` ecosystem), I haven't been able to do more exhaustive tests. Further, I'm still unsure of the following items:
* does the `communicate` block need to be wrapped in `while` loop? 
* what should the default wait time be? If any at all?