### PR TITLE
Increment version number, add PyPI badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.3.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# <img valign="middle" src="doc/source/_static/watts.svg" height="75" height="75" alt="WATTS logo"/> WATTS
+# <img valign="middle" src="https://raw.githubusercontent.com/watts-dev/watts/development/doc/source/_static/watts.svg" height="75" height="75" alt="WATTS logo"/> WATTS
 
 [![License](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
+[![PyPI](https://img.shields.io/pypi/v/watts?label=PyPI)](https://pypi.org/project/watts/)
 [![GitHub Actions build status (Linux)](https://github.com/watts-dev/watts/workflows/CI/badge.svg?branch=development)](https://github.com/watts-dev/watts/actions?query=workflow%3ACI)
 
 WATTS (Workflow and Template Toolkit for Simulation) consists of a set of Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "watts"
-version = "0.3.0"
+version = "0.3.1-dev"
 authors = [
     { name = "UChicago Argonne, LLC", email = "watts@anl.gov" },
 ]

--- a/src/watts/__init__.py
+++ b/src/watts/__init__.py
@@ -16,4 +16,4 @@ from .database import *
 # This allows a user to write watts.Quantity
 from astropy.units import Quantity
 
-__version__ = '0.3.0'
+__version__ = '0.3.1-dev'


### PR DESCRIPTION
Now that 0.3.0 has been released, this PR increments the version number to 0.3.1-dev and makes two other small changes:

- Added PyPI badge on our README
- Used a full URL for the WATTS logo on the README so that it renders properly on PyPI (you can see that right now, it [doesn't show up](https://pypi.org/project/watts/))