### PR TITLE
Allows Dakota plugin to print output on terminal while running

### DIFF
--- a/examples/Optimization_PyARC_DAKOTA/watts_dakota_exec.py
+++ b/examples/Optimization_PyARC_DAKOTA/watts_dakota_exec.py
@@ -49,6 +49,7 @@ which will be loaded and returned to Dakota.
 
 import watts
 
+watts.Database.set_default_path('/home/zooi/watts-dakota-results')
 # watts.Database.set_default_path('/default/directory') # Set default save directory if necessary
 
 params = watts.Parameters()
@@ -95,7 +96,7 @@ dakota_plugin = watts.PluginDakota(
     extra_template_inputs=['watts_pyarc_exec.py', 'dakota_driver.py'],
     extra_inputs=['pyarc_input.isotxs', 'pyarc_template', 'lumped.son', 'watts_dakota_exec.py'],
     auto_link_files = 'auto_link_file_string_name',
-    show_stdout=True) # show all the output
+    show_stdout=True,  show_stderr=True) # show all the output
 
 dakota_result = dakota_plugin(params)
 

--- a/examples/Optimization_PyARC_DAKOTA/watts_dakota_exec.py
+++ b/examples/Optimization_PyARC_DAKOTA/watts_dakota_exec.py
@@ -49,7 +49,6 @@ which will be loaded and returned to Dakota.
 
 import watts
 
-watts.Database.set_default_path('/home/zooi/watts-dakota-results')
 # watts.Database.set_default_path('/default/directory') # Set default save directory if necessary
 
 params = watts.Parameters()

--- a/src/watts/plugin_dakota.py
+++ b/src/watts/plugin_dakota.py
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
 # SPDX-License-Identifier: MIT
 
-import os
 from datetime import datetime
+import os
 from pathlib import Path
 import pickle
 from typing import List, Optional
 
-import json
 import csv
+import json
 import numpy as np
 import pandas as pd
 import subprocess
@@ -111,6 +111,8 @@ class PluginDakota(TemplatePlugin):
         self._executable = dakota_dir / f"dakota.sh"
         self.input_name = template_file
         self._auto_link_files = auto_link_files
+        self._show_stdout = show_stdout
+        self._show_stderr = show_stderr
 
         # Setup to automatically include all 'extra_inputs' and 'extra_template_inputs' 
         # to Dakota's "link files" option. Create a string of the file names in
@@ -145,6 +147,24 @@ class PluginDakota(TemplatePlugin):
     @property
     def execute_command(self):
         return [str(self.executable), "-i", self.input_name]
+
+    def run(self):
+        """Run Dakota
+
+        Parameters
+        ----------
+        """
+
+        if self._show_stdout or self._show_stderr:
+            command = self.execute_command
+
+            # run_proc() blocks the output from Dakota while the code is running.
+            # As a work-around, we explicitly use subprocess.Popen() 
+            # here without specifying 'stdout=subprocess.PIPE').
+            p = subprocess.Popen(command)
+            stdout, stderr = p.communicate()
+        else:
+            super().run()
 
 
 def run_dakota_driver(coupled_code_exec: str):


### PR DESCRIPTION
This PR allows the Dakota plugin to show output while the code is running. Current implementation only shows the output from Dakota on the terminal after the run is completed. 

This PR allows users to choose to either show the output on the terminal while Dakota is running or save the output in the log file. However, due to how `subprocess.Popen()` works, if a user chooses to show Dakota's output on the terminal, the output will NOT be saved in the log file. 