### PR TITLE
Add Database.remove method to remove a single result

### DIFF
--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -326,7 +326,23 @@ plugins. If you want to change the default database path used in plugins, the
     >>> db.path
     PosixPath('/opt/watts_db')
 
-To clear results from the database, simply use the
+To remove a result from the databse, you can call the
+:meth:`~watts.Database.remove` method, passing a :class:`watts.Results` object::
+
+    >>> db = watts.Database()
+    >>> db
+    [<ResultsOpenMC: 2022-01-01 12:05:02.130384>,
+     <ResultsOpenMC: 2022-01-01 12:11:38.037813>,
+     <ResultsMOOSE: 2022-01-02 08:45:12.846409>]
+    >>> moose_result = db[-1]
+    >>> db.remove(moose_result)
+    >>> db
+    [<ResultsOpenMC: 2022-01-01 12:05:02.130384>,
+     <ResultsOpenMC: 2022-01-01 12:11:38.037813>]
+
+Note that removing a database result will delete the data directory associated
+with the result but will not affect the input files stored in their original
+location on your system. To clear all results from the database, simply use the
 :meth:`~watts.Database.clear` method:
 
 .. code-block::
@@ -335,5 +351,7 @@ To clear results from the database, simply use the
     >>> db
     []
 
-Be aware that clearing the database **will** delete all the corresponding
-results on disk, including input and output files from the workflow.
+As with the :meth:`~watts.Database.remove` method, clearing the database will
+delete all the corresponding results on disk, including copies of the input and
+output files from the workflow stored in the data directory. Original input
+files stored outside the database directory will be unaffected.

--- a/src/watts/database.py
+++ b/src/watts/database.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 import pprint
 import shutil
-from typing import List, Union
+from typing import Union
 from warnings import warn
 
 import platformdirs
@@ -135,6 +135,18 @@ class Database(Sequence):
         for dir in self.path.iterdir():
             shutil.rmtree(dir)
         self._results.clear()
+
+    def remove(self, result: Results):
+        """Remove a single result from the database
+
+        Parameters
+        ----------
+        result
+            Result to remove from the database
+
+        """
+        self._results.remove(result)
+        shutil.rmtree(result.base_path)
 
     def show_summary(self):
         """Show a summary of results in database"""


### PR DESCRIPTION
This PR adds a `Database.remove` method that allows a user to remove a single result from the `Database` object. I've updated the user documentation to reflect the change.

Closes #64. @munkm I've tried to be more explicit in the user documentation about the side effect of clearing the database (what files are deleted and what files are retained). Hopefully it's clear but let me know if you think changes are still needed!