### PR TITLE
Add new box on documentation landing page for getting help

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,6 +44,12 @@ WATTS
         Once you're acquainted with the basics of watts, check out our examples
         that illustrate a variety of use cases.
 
+    .. grid-item-card:: \ :octicon:`comment-discussion;2em` Getting Help
+        :text-align: center
+        :link: https://github.com/watts-dev/watts/discussions
+
+        Have questions? Click here for our discussions forum where you can ask
+        questions and engage with our development team.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Closes #63. This PR adds a new box on our documentation landing page referring people to the [discussions](https://github.com/watts-dev/watts/discussions) page, which has just been enabled.

Here's a screenshot of what the new docs will look like:
![image](https://user-images.githubusercontent.com/743095/199099433-18ff3858-fd13-4ff1-bea0-5bfcd0df191b.png)
