### PR TITLE
Generalize the template-based plugin to be used with arbitrary executables

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -7,4 +7,5 @@ Developer's Guide
    :maxdepth: 2
 
    contributing
+   plugins
    styleguide

--- a/doc/source/dev/plugins.rst
+++ b/doc/source/dev/plugins.rst
@@ -1,0 +1,88 @@
+.. devguide_plugins:
+
+Developing Plugins
+------------------
+
+As discussed in the user's guide, WATTS has a variety of plugins for different
+codes (primarily focused on application codes in nuclear science and
+engineering) that are already available. If you wish to use WATTS with a code
+that does not already have a plugin available, extending WATTS to handle another
+code can be done quite easily.
+
+There are two ways to incorporate new codes into WATTS. First, if the code uses
+a text-based input, the :class:`~watts.PluginTemplate` class can be used to
+specify the executable, how it should be invoked from a command-line, and a
+template for the input file. For example, if you have a code called ``goblin``
+that should be executed from a command line as:
+
+.. code-block:: sh
+
+    goblin input=filein.gbl
+
+a plugin can be set up as::
+
+    goblin = watts.PluginTemplate(
+        executable='goblin',
+        execute_command=['{self.executable}', 'input={self.input_name}'],
+        template_file='filein.gbl'
+    )
+
+where ``filein.gbl`` is a template input for the ``goblin`` code. Executing the
+code is done by passing it a set of parameters::
+
+    params = watts.Parameters()
+    ...
+
+    result = goblin(params)
+
+Plugin Customization
+++++++++++++++++++++
+
+If the :class:`~watts.PluginTemplate` class doesn't quite meet your needs, you
+will need to write your own plugin class that is a subclass of either
+:class:`~watts.Plugin` or :class:`~watts.PluginTemplate`. Subclassing
+:class:`~watts.PluginTemplate` is appropriate if the code you're working with
+uses text-based input files. If text-based input files are not used, you will
+need to subclass the more general :class:`~watts.Plugin` class.
+
+In either case, your plugin class will need to provide one or more of the
+following:
+
+- A ``prerun(params)`` method that is responsible for rendering inputs based on
+  the parameters that were passed and any other tasks that need to be taken care
+  of prior to execution.
+- A ``run(**kwargs)`` method that is responsible for executing the code using
+  the rendered inputs. Keyword arguments are passed through when calling the
+  plugin.
+- A ``postrun(params, name)`` method that is responsible for collecting a list
+  of input and output files and returning a :class:`~watts.Results` object.
+
+If you are subclassing :class:`watts.PluginGeneric`, note that default
+implementations of ``prerun``, ``run``, and ``postrun`` are already provided.
+The executable and command-line arguments can also be customized through the
+``executable`` and ``execute_command`` properties. Finally, the unit system to
+be used for performing unit conversions is specified as an argument that is
+passed through the ``__init__`` methods.
+
+
+Results Customization
++++++++++++++++++++++
+
+The basic :class:`~watts.Results` class stores a list of input and output files
+associated with the execution of a plugin, the :class:`~watts.Parameters` that
+were used to generate input files, and a timestamp. When writing your own
+plugin, if you don't need to provide further customization of the results, you
+should simply subclass :class:`~watts.Results` with a name matching the plugin.
+For example, if you have::
+
+    class PluginGoblin(PluginGeneric):
+        ...
+
+A minimal corresponding results class would be::
+
+    class ResultsGoblin(Results):
+        """Results from a Goblin simulation"""
+
+However, you may wish to provide extra methods and properties that allow users
+of your plugin to easily interrogate results (for example, pulling out key
+numerical results from output files).

--- a/doc/source/dev/plugins.rst
+++ b/doc/source/dev/plugins.rst
@@ -10,7 +10,7 @@ that does not already have a plugin available, extending WATTS to handle another
 code can be done quite easily.
 
 There are two ways to incorporate new codes into WATTS. First, if the code uses
-a text-based input, the :class:`~watts.PluginTemplate` class can be used to
+a text-based input, the :class:`~watts.PluginGeneric` class can be used to
 specify the executable, how it should be invoked from a command-line, and a
 template for the input file. For example, if you have a code called ``goblin``
 that should be executed from a command line as:
@@ -21,27 +21,39 @@ that should be executed from a command line as:
 
 a plugin can be set up as::
 
-    goblin = watts.PluginTemplate(
+    goblin = watts.PluginGeneric(
         executable='goblin',
         execute_command=['{self.executable}', 'input={self.input_name}'],
         template_file='filein.gbl'
     )
 
-where ``filein.gbl`` is a template input for the ``goblin`` code. Executing the
-code is done by passing it a set of parameters::
+where ``filein.gbl`` is a template input for the ``goblin`` code. Alternatively,
+the command-line arguments can be specified as a single string::
+
+    goblin = watts.PluginGeneric(
+        executable='goblin',
+        execute_command='{self.executable} input={self.input_name}',
+        template_file='filein.gbl'
+    )
+
+Executing the code is done by passing the plugin instance a set of parameters::
 
     params = watts.Parameters()
     ...
 
     result = goblin(params)
 
+The ``result`` object will be a :class:`~watts.Results` instance, which holds
+lists of input/output files, the parameters used to generate the results, and a
+timestamp.
+
 Plugin Customization
 ++++++++++++++++++++
 
-If the :class:`~watts.PluginTemplate` class doesn't quite meet your needs, you
+If the :class:`~watts.PluginGeneric` class doesn't quite meet your needs, you
 will need to write your own plugin class that is a subclass of either
-:class:`~watts.Plugin` or :class:`~watts.PluginTemplate`. Subclassing
-:class:`~watts.PluginTemplate` is appropriate if the code you're working with
+:class:`~watts.Plugin` or :class:`~watts.PluginGeneric`. Subclassing
+:class:`~watts.PluginGeneric` is appropriate if the code you're working with
 uses text-based input files. If text-based input files are not used, you will
 need to subclass the more general :class:`~watts.Plugin` class.
 

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -11,6 +11,7 @@ API Reference
    watts.Database
    watts.Parameters
    watts.Plugin
+   watts.PluginGeneric
    watts.PluginABCE
    watts.PluginMCNP
    watts.PluginMOOSE

--- a/doc/source/user/getting_started.rst
+++ b/doc/source/user/getting_started.rst
@@ -141,3 +141,54 @@ five MCNP simulations:
      0.97663+/-0.00063,
      1.24086+/-0.00075,
      1.47152+/-0.00081]
+
+Your First ``watts`` Program
+++++++++++++++++++++++++++++
+
+To show how the various classes fit together, the example below creates a plugin
+for a "code" (in this case, just the Linux ``cat`` command) and executes the
+code on a templated input file that is rendered using parameters that are
+defined in a :class:`~watts.Parameters` instance. This example assumes we have a
+file called triangle.txt containing the following text:
+
+.. code-block:: jinja
+
+    width={{ width }}
+    height={{ height }}
+    area={{ 0.5 * height * width }}
+
+The ``watts`` script is as follows::
+
+    import watts
+
+    # Create a plugin for the 'cat' code
+    plugin = watts.PluginGeneric(
+        executable='cat',
+        execute_command=['{self.executable}', '{self.input_name}'],
+        template_file='triangle.txt',
+        unit_system='cgs'
+    )
+
+    # Define some parameters that will be used to render the input file
+    params = watts.Parameters()
+    params['width'] = watts.Quantity(1.0, 'm')
+    params['height'] = watts.Quantity(1.0, 'inch')
+
+    # Execute the plugin
+    result = plugin(params)
+
+    # Show the resulting input file
+    print(result.stdout)
+
+Running this example will produce the following output:
+
+.. code-block:: text
+
+    width=100.0
+    height=2.54
+    area=127.0
+
+When the plugin is executed, the ``cat`` command is called on the rendered input
+file, which is just the triangle.txt file where the parameters have been filled
+in. Note that the physical quantities were :ref:`converted <units>` to
+centimeters since we indicated that this plugin uses CGS units.

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -167,7 +167,7 @@ Specifying an Executable
 Each plugin has a default executable name for the underlying code. For example,
 the :class:`~watts.PluginMCNP` class uses the executable ``mcnp6`` by default.
 You can both view and/or change the executable using the
-:class:`~watts.TemplatePlugin.executable` attribute:
+:class:`~watts.PluginGeneric.executable` attribute:
 
 .. code-block:: pycon
 

--- a/examples/1App_BISON_MetalFuel/watts_exec.py
+++ b/examples/1App_BISON_MetalFuel/watts_exec.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
 # SPDX-License-Identifier: MIT
 
-from math import cos, pi
+from pathlib import Path
 import os
+
 import watts
 
 params = watts.Parameters()
@@ -38,12 +39,14 @@ params['Wrapping_Wire_Thickness'] = 1.067e-03 # m
 params.show_summary(show_metadata=False, sort_by='key')
 
 # MOOSE Workflow
-# set your BISON directorate as BISON_DIR
+# set your BISON directory as BISON_DIR
 
-moose_app_type = "bison"
-app_dir = os.environ[moose_app_type.upper() + "_DIR"]
-moose_plugin = watts.PluginMOOSE('bison_template', show_stdout=True) # show all the output
-moose_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+app_dir = Path(os.environ["BISON_DIR"])
+moose_plugin = watts.PluginMOOSE(
+    'bison_template',
+    executable=app_dir / 'bison-opt',
+    show_stdout=True
+)
 moose_result = moose_plugin(params, mpi_args=['mpiexec', '-n', '2'])
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])

--- a/examples/1App_MOOSE-MultiApp_Simple/watts_exec.py
+++ b/examples/1App_MOOSE-MultiApp_Simple/watts_exec.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 """
-This example provides a demonstration on how to use WATTS to perform a simple simulation leveraging MOOSE's MultiApps system.
+This example provides a demonstration on how to use WATTS to perform a simple
+simulation leveraging MOOSE's MultiApps system.
 """
 
-from math import cos, pi
+from pathlib import Path
 import os
+
 import watts
 
 params = watts.Parameters()
@@ -18,12 +20,14 @@ params['Swelling_Coefficient'] = 3000.0 # K.
 params.show_summary(show_metadata=False, sort_by='key')
 
 # MOOSE Workflow
-# set your BISON directorate as BISON_DIR
+# set your BISON directory as BISON_DIR
 
-moose_app_type = "bison"
-app_dir = os.environ[moose_app_type.upper() + "_DIR"]
-moose_plugin = watts.PluginMOOSE('main.tmpl', extra_inputs=['main_in.e', 'sub.i'])
-moose_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+app_dir = Path(os.environ["BISON_DIR"])
+moose_plugin = watts.PluginMOOSE(
+    'main.tmpl',
+    executable=app_dir / 'bison-opt',
+    extra_inputs=['main_in.e', 'sub.i']
+)
 moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])

--- a/examples/1App_PyARC_UnitCell/pyarc_template
+++ b/examples/1App_PyARC_UnitCell/pyarc_template
@@ -47,12 +47,12 @@ geometry{
     }
 }
 calculations{
-
+	lumped_element_text_file( lu35 ) = "lumped.son"
     mcc3{
        xslib            = "endf7.0"
        egroupname       = ANL33
        scattering_order = 1
-       lumped_element_text_file( lu35 ) = "lumped.son"
+       
         cell( a ){
             associated_sub_assembly     = sub_assembly_name
         }

--- a/examples/1App_SAM_VHTR/watts_exec.py
+++ b/examples/1App_SAM_VHTR/watts_exec.py
@@ -12,6 +12,8 @@ the results stored in CSV files are displayed to the user.
 
 from math import cos, pi
 import os
+from pathlib import Path
+
 import watts
 from astropy.units import Quantity
 
@@ -52,12 +54,10 @@ params['control_pin_rad'] = Quantity(9.9, "mm") # Automatically converts to 'm' 
 params.show_summary(show_metadata=False, sort_by='key')
 
 # MOOSE Workflow
-# set your SAM directorate as SAM_DIR
+# set your SAM directory as SAM_DIR
 
-moose_app_type = "SAM"
-app_dir = os.environ[moose_app_type.upper() + "_DIR"]
-moose_plugin = watts.PluginMOOSE(moose_app_type.lower() + '_template') # show all the output
-moose_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+app_dir = Path(os.environ["SAM_DIR"])
+moose_plugin = watts.PluginMOOSE('sam_template', executable=app_dir / 'sam-opt')
 moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])

--- a/examples/Main_SAM-OpenMC_VHTR/watts_main.py
+++ b/examples/Main_SAM-OpenMC_VHTR/watts_main.py
@@ -7,10 +7,11 @@ and applies it in a procedure for re-use in optimization and
 sensitivity analyses.
 """
 
+from pathlib import Path
 from math import cos, pi
 import os
 import watts
-from statistics import mean, stdev
+from statistics import mean
 from openmc_template import build_openmc_model
 
 params = watts.Parameters()
@@ -64,11 +65,13 @@ def calc_workflow(X):
     print("FuelPin_rad / cool_hole_rad", X[0], X[1])
 
     # MOOSE Workflow
-    # set your SAM directorate as SAM_DIR
-    moose_app_type = "SAM"
-    app_dir = os.environ[moose_app_type.upper() + "_DIR"]
-    sam_plugin = watts.PluginMOOSE('../1App_SAM_VHTR/sam_template', show_stderr=False) # does not show anything
-    sam_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+    # set your SAM directory as SAM_DIR
+    app_dir = Path(os.environ["SAM_DIR"])
+    sam_plugin = watts.PluginMOOSE(
+        '../1App_SAM_VHTR/sam_template',
+        executable=app_dir / 'sam-opt',
+        show_stderr=False
+    )
     sam_result = sam_plugin(params)
     max_Tf = max(sam_result.csv_data[f'max_Tf_{i}'][-1] for i in range(1, 6))
     avg_Tf = mean(sam_result.csv_data[f'avg_Tf_{i}'][-1] for i in range(1, 6))

--- a/examples/MultiApp_SAM-OpenMC_VHTR/watts_exec.py
+++ b/examples/MultiApp_SAM-OpenMC_VHTR/watts_exec.py
@@ -15,6 +15,7 @@ the main results from OpenMC are printed out and stored
 in the params database.
 """
 
+from pathlib import Path
 from math import cos, pi
 import os
 import watts
@@ -70,12 +71,14 @@ params.show_summary(show_metadata=True, sort_by='time')
 
 
 # MOOSE Workflow
-# set your SAM directorate as SAM_DIR
+# set your SAM directory as SAM_DIR
 
-moose_app_type = "SAM"
-app_dir = os.environ[moose_app_type.upper() + "_DIR"]
-moose_plugin = watts.PluginMOOSE('../1App_SAM_VHTR/sam_template', show_stderr=True) # show only error
-moose_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+app_dir = Path(os.environ["SAM_DIR"])
+moose_plugin = watts.PluginMOOSE(
+    '../1App_SAM_VHTR/sam_template',
+    executable=app_dir / 'sam-opt',
+    show_stderr=True
+)
 moose_result = moose_plugin(params)
 for key in moose_result.csv_data:
     print(key, moose_result.csv_data[key])

--- a/examples/MultiStep_Griffin-BISON-Sockeye_MR/watts_exec.py
+++ b/examples/MultiStep_Griffin-BISON-Sockeye_MR/watts_exec.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022 UChicago Argonne, LLC
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
 import os
 import watts
 
@@ -11,15 +12,15 @@ Second step is a Null transient simulation to confirm the steady state obtained
 Third step is a real transient simulation induced by loss of cooling capacity
 """
 
-# set your SuperMoose directory as SUPER_MOOSE
+# set your SuperMoose directory as SUPER_MOOSE_DIR
 # As Sockeye is run through dynamic linking
 # set your Sockeye directory as SOCKEYE_DIR
 
 if not os.getenv("SOCKEYE_DIR"):
     raise RuntimeError("SOCKEYE_DIR must be set to enable this example.")
 # MOOSE app type to run
-moose_app_type = "super_moose"
-app_dir = os.environ[moose_app_type.upper() + "_DIR"]
+app_dir = Path(os.enrivon["SUPER_MOOSE_DIR"])
+moose_exec = app_dir / "super_moose-opt"
 
 # Steady State Parameters
 params_ss = watts.Parameters()
@@ -42,8 +43,11 @@ params_ss.show_summary(show_metadata=False, sort_by='key')
 # MOOSE Workflow for steady state
 print("Steady-state calculation")
 mpi_args = ['mpiexec', '-n', '40']
-moose_plugin_ss = watts.PluginMOOSE('MP_ss_griffin.tmpl', extra_inputs=['MP_ss_moose.i', 'MP_ss_sockeye.i', '3D_unit_cell_FY21_level-1_bison.e', '3D_unit_cell_FY21_supersimple.e', 'unitcell_nogap_hom_xml_G11_df_MP.xml'])
-moose_plugin_ss.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+moose_plugin_ss = watts.PluginMOOSE(
+    'MP_ss_griffin.tmpl',
+    executable=moose_exec,
+    extra_inputs=['MP_ss_moose.i', 'MP_ss_sockeye.i', '3D_unit_cell_FY21_level-1_bison.e', '3D_unit_cell_FY21_supersimple.e', 'unitcell_nogap_hom_xml_G11_df_MP.xml']
+)
 moose_result_ss = moose_plugin_ss(params_ss, mpi_args=mpi_args)
 for key in moose_result_ss.csv_data:
     print(key, moose_result_ss.csv_data[key])
@@ -58,8 +62,12 @@ params_trN = params_ss
 
 # MOOSE Workflow for Null transient
 print("Null transient calculation")
-moose_plugin_trN = watts.PluginMOOSE('MP_trN_griffin.tmpl', show_stdout=False, extra_inputs=['MP_trN_moose.i', 'MP_trN_sockeye.i', 'unitcell_nogap_hom_xml_G11_df_MP.xml'])
-moose_plugin_trN.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+moose_plugin_trN = watts.PluginMOOSE(
+    'MP_trN_griffin.tmpl',
+    executable=moose_exec,
+    show_stdout=False,
+    extra_inputs=['MP_trN_moose.i', 'MP_trN_sockeye.i', 'unitcell_nogap_hom_xml_G11_df_MP.xml']
+)
 moose_result_trN = moose_plugin_trN(params_trN, mpi_args=mpi_args)
 for key in moose_result_trN.csv_data:
     print(key, moose_result_trN.csv_data[key])
@@ -78,8 +86,12 @@ params_tr = params_ss
 
 # MOOSE Workflow for transient
 print("Transient calculation")
-moose_plugin_tr = watts.PluginMOOSE('MP_tr_griffin.tmpl', show_stdout=True, extra_inputs=['MP_tr_moose.i', 'MP_tr_sockeye.i', 'unitcell_nogap_hom_xml_G11_df_MP.xml'])
-moose_plugin_tr.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+moose_plugin_tr = watts.PluginMOOSE(
+    'MP_tr_griffin.tmpl',
+    executable=moose_exec,
+    show_stdout=True,
+    extra_inputs=['MP_tr_moose.i', 'MP_tr_sockeye.i', 'unitcell_nogap_hom_xml_G11_df_MP.xml']
+)
 moose_result_tr = moose_plugin_tr(params_tr, mpi_args=mpi_args)
 for key in moose_result_tr.csv_data:
     print(key, moose_result_tr.csv_data[key])

--- a/examples/Optimization_PyARC_DAKOTA/pyarc_template
+++ b/examples/Optimization_PyARC_DAKOTA/pyarc_template
@@ -47,12 +47,12 @@ geometry{
     }
 }
 calculations{
-
+	lumped_element_text_file( lu35 ) = "lumped.son"
     mcc3{
        xslib            = "endf7.0"
        egroupname       = ANL33
        scattering_order = 1
-       lumped_element_text_file( lu35 ) = "lumped.son"
+       
         cell( a ){
             associated_sub_assembly     = sub_assembly_name
         }

--- a/examples/ParamStudy_SAM_VHTR/watts_exec.py
+++ b/examples/ParamStudy_SAM_VHTR/watts_exec.py
@@ -15,8 +15,9 @@ create results of different lengths to show that the
 output CSV file can accept columns of different lengths.
 """
 
-from math import cos, pi
+from pathlib import Path
 import os
+
 import watts
 import pandas as pd
 from astropy.units import Quantity
@@ -45,8 +46,7 @@ params['Graphite_thickness'] = (params['Lattice_pitch'] - params['FuelPin_rad'] 
 params.show_summary(show_metadata=False, sort_by='key')
 
 # MOOSE Workflow
-moose_app_type = "SAM"
-app_dir = os.environ[moose_app_type.upper() + "_DIR"]
+app_dir = Path(os.environ["SAM_DIR"])
 
 power = [100_000, 250_000, 300_000, 400_000, 500_000] # Watts
 endtime = [50, 100, 100, 50, 50] # End time is varied to artificially create results of different lengths.
@@ -56,8 +56,7 @@ for i in range(len(power)):
     params['endtime'] = endtime[i]
 
     # Execute WATTS
-    moose_plugin = watts.PluginMOOSE(moose_app_type.lower() + '_template') # show all the output
-    moose_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+    moose_plugin = watts.PluginMOOSE('sam_template', executable=app_dir / 'sam-opt')
     moose_result = moose_plugin(params)
 
     # Add items to dictionary.

--- a/examples/PicardIterations_SAM-OpenMC_VHTR/watts_exec.py
+++ b/examples/PicardIterations_SAM-OpenMC_VHTR/watts_exec.py
@@ -9,6 +9,7 @@ until convergence. This example uses a simple VHTR unit-cell
 model with 1 coolant channel surrounded by graphite and fuel.
 """
 
+from pathlib import Path
 from math import cos, pi
 import os
 import watts
@@ -64,13 +65,15 @@ conv_it = True
 nmax_it = 5
 conv_criteria = 1e-4
 
+app_dir = Path(os.environ["SAM_DIR"])
 list_keff = []
 while conv_it:
     # MOOSE Workflow
-    moose_app_type = "SAM"
-    app_dir = os.environ[moose_app_type.upper() + "_DIR"]
-    sam_plugin = watts.PluginMOOSE('../1App_SAM_VHTR/sam_template', show_stderr=True) # show only error
-    sam_plugin.executable = app_dir + "/" + moose_app_type.lower() + "-opt"
+    sam_plugin = watts.PluginMOOSE(
+        '../1App_SAM_VHTR/sam_template',
+        executable=app_dir / "sam-opt",
+        show_stderr=True
+    )
     sam_result = sam_plugin(params)
 
     # get temperature from SAM results

--- a/src/watts/__init__.py
+++ b/src/watts/__init__.py
@@ -11,6 +11,7 @@ from .plugin_mcnp import *
 from .plugin_serpent import *
 from .plugin_abce import *
 from .plugin_dakota import *
+from .results import *
 from .template import *
 from .parameters import *
 from .database import *

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -8,7 +8,7 @@ import uuid
 from pathlib import Path
 import shutil
 import time
-from typing import Optional, List
+from typing import Optional, List, Union
 
 from .database import Database
 from .fileutils import cd_tmpdir, PathLike, tee_stdout, tee_stderr, run as run_proc
@@ -148,7 +148,8 @@ class PluginGeneric(Plugin):
         List of command-line arguments, where each is formatted using the
         instance of the class as ``self``. The first string normally indicates
         the executable, i.e. "{self.executable}". The rendered input file can be
-        accessed as "{self.input_name}".
+        accessed as "{self.input_name}". A single string of command-line
+        arguments is also accepted.
     template_file
         Path to template file
     extra_inputs
@@ -172,7 +173,7 @@ class PluginGeneric(Plugin):
     """
     def __init__(self,
         executable: PathLike,
-        execute_command: List[str],
+        execute_command: Union[List[str], str],
         template_file: PathLike,
         extra_inputs: Optional[List[PathLike]] = None,
         extra_template_inputs: Optional[List[PathLike]] = None,
@@ -188,7 +189,10 @@ class PluginGeneric(Plugin):
             self.extra_render_templates = [TemplateRenderer(f, '') for f in extra_template_inputs]
 
         self.executable = executable
-        self._execute_command = execute_command
+        if isinstance(execute_command, str):
+            self._execute_command = execute_command.split()
+        else:
+            self._execute_command = execute_command
 
     @property
     def executable(self) -> Path:

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -64,7 +64,7 @@ class Plugin(ABC):
         ...
 
     @abstractmethod
-    def postrun(self, params) -> Results:
+    def postrun(self, params, name) -> Results:
         ...
 
     @property

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -240,3 +240,55 @@ class TemplatePlugin(Plugin):
         if extra_args is None:
             extra_args = []
         run_proc(mpi_args + self.execute_command + extra_args)
+
+
+class PluginGeneric(TemplatePlugin):
+    """Plugin for a generic executable
+
+    This class can be used to control the execution of an arbitrary executable,
+    first rendering one or more templated input files.
+
+    Parameters
+    ----------
+    executable
+        Path to executable
+    execute_command
+        List of command-line arguments, where each is formatted using the
+        instance of the class as ``self``. The first string normally indicates
+        the executable, i.e. "{self.executable}". The rendered input file can be
+        accessed as "{self.input_name}".
+    template_file
+        Path to template file
+    extra_inputs
+        Extra (non-templated) input files
+    extra_template_inputs
+        Extra templated input files
+    show_stdout
+        Whether to display output from stdout when :math:`run` is called
+    show_stderr
+        Whether to display output from stderr when :meth:`run` is called
+    unit_system : {'si', 'cgs'}
+        Unit system to convert to when rendering input files
+
+    """
+
+    def __init__(self,
+        executable: PathLike,
+        execute_command: List[str],
+        template_file: PathLike,
+        extra_inputs: Optional[List[PathLike]] = None,
+        extra_template_inputs: Optional[List[PathLike]] = None,
+        show_stdout: bool = False,
+        show_stderr: bool = False,
+        unit_system: str = 'si'
+    ):
+        super().__init__(template_file, extra_inputs, extra_template_inputs,
+                         show_stdout, show_stderr)
+        self.executable = executable
+        self.input_name = "input_rendered"
+        self._execute_command = execute_command
+        self.unit_system = unit_system
+
+    @property
+    def execute_command(self):
+        return [item.format(self=self) for item in self._execute_command]

--- a/src/watts/plugin_mcnp.py
+++ b/src/watts/plugin_mcnp.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from uncertainties import ufloat
 
 from .fileutils import PathLike
-from .plugin import TemplatePlugin
+from .plugin import PluginGeneric
 from .results import Results
 
 
@@ -49,7 +49,7 @@ class ResultsMCNP(Results):
                     "Could not determine final k-effective value from MCNP output")
 
 
-class PluginMCNP(TemplatePlugin):
+class PluginMCNP(PluginGeneric):
     """Plugin for running MCNP
 
     Parameters
@@ -69,6 +69,8 @@ class PluginMCNP(TemplatePlugin):
     ----------
     executable
         Path to MCNP executable
+    execute_command
+        List of command-line arguments used to call the executable
 
     """
 
@@ -76,12 +78,8 @@ class PluginMCNP(TemplatePlugin):
                  extra_inputs: Optional[List[str]] = None,
                  extra_template_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        super().__init__(template_file, extra_inputs, extra_template_inputs,
-                         show_stdout, show_stderr)
-        self._executable = Path('mcnp6')
+        super().__init__(
+            'mcnp6', ['{self.executable}', 'i={self.input_name}'],
+            template_file, extra_inputs, extra_template_inputs,
+            show_stdout, show_stderr, unit_system='cgs')
         self.input_name = "mcnp_input"
-        self.unit_system = 'cgs'
-
-    @property
-    def execute_command(self):
-        return [str(self.executable), f"i={self.input_name}"]

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from .fileutils import PathLike
 from .parameters import Parameters
-from .plugin import TemplatePlugin
+from .plugin import PluginGeneric
 from .results import Results
 
 
@@ -77,7 +77,7 @@ class ResultsMOOSE(Results):
         return csv_data
 
 
-class PluginMOOSE(TemplatePlugin):
+class PluginMOOSE(PluginGeneric):
     """Plugin for running MOOSE
 
     Parameters
@@ -97,6 +97,8 @@ class PluginMOOSE(TemplatePlugin):
     ----------
     executable
         Path to MOOSE executable
+    execute_command
+        List of command-line arguments used to call the executable
 
     """
 
@@ -104,11 +106,9 @@ class PluginMOOSE(TemplatePlugin):
                  extra_inputs: Optional[List[str]] = None,
                  extra_template_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        super().__init__(template_file, extra_inputs, extra_template_inputs,
-                         show_stdout, show_stderr)
-        self._executable = Path('moose-opt')
+        executable = 'moose-opt'
+        execute_command = ['{self.executable}', '-i', '{self.input_name}']
+        super().__init__(
+            executable, execute_command, template_file, extra_inputs,
+            extra_template_inputs, show_stdout, show_stderr)
         self.input_name = "MOOSE.i"
-
-    @property
-    def execute_command(self):
-        return [str(self.executable), "-i", self.input_name]

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 from datetime import datetime
-from pathlib import Path
 from typing import List, Optional
 
 import numpy as np
@@ -84,6 +83,8 @@ class PluginMOOSE(PluginGeneric):
     ----------
     template_file
         Templated MOOSE input
+    executable
+        Path to MOOSE executable
     extra_inputs
         List of extra (non-templated) input files that are needed
     extra_template_inputs
@@ -103,10 +104,10 @@ class PluginMOOSE(PluginGeneric):
     """
 
     def __init__(self, template_file: str,
+                 executable: PathLike = 'moose-opt',
                  extra_inputs: Optional[List[str]] = None,
                  extra_template_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        executable = 'moose-opt'
         execute_command = ['{self.executable}', '-i', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -10,7 +10,7 @@ from typing import Mapping, List, Optional
 
 from .fileutils import PathLike
 from .parameters import Parameters
-from .plugin import TemplatePlugin
+from .plugin import PluginGeneric
 from .results import Results
 
 
@@ -40,7 +40,7 @@ class ResultsPyARC(Results):
         self.results_data = results_data
 
 
-class PluginPyARC(TemplatePlugin):
+class PluginPyARC(PluginGeneric):
     """Plugin for running PyARC
 
     Parameters
@@ -67,12 +67,12 @@ class PluginPyARC(TemplatePlugin):
                  extra_inputs: Optional[List[str]] = None,
                  extra_template_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        super().__init__(template_file, extra_inputs, extra_template_inputs,
-                         show_stdout, show_stderr)
-        self._executable = Path(os.environ.get('PyARC_DIR', 'PyARC.py'))
+        executable = Path(os.environ.get('PyARC_DIR', 'PyARC.py'))
+        super().__init__(executable, None, template_file, extra_inputs,
+                         extra_template_inputs, show_stdout, show_stderr)
         self.input_name = "pyarc_input.son"
 
-    @TemplatePlugin.executable.setter
+    @PluginGeneric.executable.setter
     def executable(self, exe: PathLike):
         if Path(exe).exists():
             raise RuntimeError(f"{self.plugin_name} executable '{exe}' is missing.")

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -67,15 +67,20 @@ class PluginPyARC(PluginGeneric):
                  extra_inputs: Optional[List[str]] = None,
                  extra_template_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        executable = Path(os.environ.get('PyARC_DIR', 'PyARC.py'))
+        executable = Path(os.environ.get('PyARC_DIR', ''))
         super().__init__(executable, None, template_file, extra_inputs,
                          extra_template_inputs, show_stdout, show_stderr)
         self.input_name = "pyarc_input.son"
 
     @PluginGeneric.executable.setter
     def executable(self, exe: PathLike):
-        if Path(exe).exists():
-            raise RuntimeError(f"{self.plugin_name} executable '{exe}' is missing.")
+        pyarc_module = Path(exe) / 'PyARC.py'
+        if not pyarc_module.is_file():
+            raise RuntimeError(
+                f"{self.plugin_name} module '{pyarc_module}' does not exist. The "
+                "PyARC_DIR environment variable needs to be set to a directory "
+                "containing the PyARC.py module."
+            )
         self._executable = Path(exe)
 
     def run(self, **kwargs: Mapping):

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -102,10 +102,10 @@ class PluginSAS(PluginGeneric):
         # Check OS to make sure the extension of the executable is correct.
         # Linux and macOS have different executables but both are ".x".
         # The Windows executable is ".exe".
+        ext = "exe" if platform.system() == "Windows" else "x"
         sas_dir = Path(os.environ.get("SAS_DIR", ""))
         self._conv_channel = sas_dir / f"CHANNELtoCSV.{ext}"
         self._conv_primar4 = sas_dir / f"PRIMAR4toCSV.{ext}"
-        ext = "exe" if platform.system() == "Windows" else "x"
         executable = sas_dir / f"sas.{ext}"
         execute_command = ['{self.executable}', '-i', '{self.input_name}',
                            '-o', 'out.txt']

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from .fileutils import PathLike, run as run_proc
 from .parameters import Parameters
-from .plugin import TemplatePlugin
+from .plugin import PluginGeneric
 from .results import Results
 
 
@@ -66,7 +66,7 @@ class ResultsSAS(Results):
         return csv_data
 
 
-class PluginSAS(TemplatePlugin):
+class PluginSAS(PluginGeneric):
     """Plugin for running SAS
 
     Parameters
@@ -86,6 +86,8 @@ class PluginSAS(TemplatePlugin):
     ----------
     executable
         Path to SAS executable
+    execute_command
+        List of command-line arguments used to call the executable
     conv_channel
         Path to CHANNELtoCSV utility executable
     conv_primar4
@@ -97,17 +99,19 @@ class PluginSAS(TemplatePlugin):
                   extra_inputs: Optional[List[str]] = None,
                   extra_template_inputs: Optional[List[PathLike]] = None,
                   show_stdout: bool = False, show_stderr: bool = False):
-        super().__init__(template_file, extra_inputs, extra_template_inputs,
-                         show_stdout, show_stderr)
-
         # Check OS to make sure the extension of the executable is correct.
         # Linux and macOS have different executables but both are ".x".
         # The Windows executable is ".exe".
         sas_dir = Path(os.environ.get("SAS_DIR", ""))
-        ext = "exe" if platform.system() == "Windows" else "x"
-        self._executable = sas_dir / f"sas.{ext}"
         self._conv_channel = sas_dir / f"CHANNELtoCSV.{ext}"
         self._conv_primar4 = sas_dir / f"PRIMAR4toCSV.{ext}"
+        ext = "exe" if platform.system() == "Windows" else "x"
+        executable = sas_dir / f"sas.{ext}"
+        execute_command = ['{self.executable}', '-i', '{self.input_name}',
+                           '-o', 'out.txt']
+
+        super().__init__(executable, execute_command, template_file, extra_inputs,
+                         extra_template_inputs, show_stdout, show_stderr)
         self.input_name = "SAS.inp"
 
     @property

--- a/src/watts/plugin_serpent.py
+++ b/src/watts/plugin_serpent.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from uncertainties import ufloat
 
 from .fileutils import PathLike
-from .plugin import TemplatePlugin
+from .plugin import PluginGeneric
 from .results import Results
 
 
@@ -34,7 +34,7 @@ class ResultsSerpent(Results):
     """
 
 
-class PluginSerpent(TemplatePlugin):
+class PluginSerpent(PluginGeneric):
     """Plugin for running Serpent
 
     Parameters
@@ -54,6 +54,8 @@ class PluginSerpent(TemplatePlugin):
     ----------
     executable
         Path to Serpent executable
+    execute_command
+        List of command-line arguments used to call the executable
 
     """
 
@@ -61,12 +63,9 @@ class PluginSerpent(TemplatePlugin):
                  extra_inputs: Optional[List[str]] = None,
                  extra_template_inputs: Optional[List[PathLike]] = None,
                  show_stdout: bool = False, show_stderr: bool = False):
-        super().__init__(template_file, extra_inputs, extra_template_inputs,
-                         show_stdout, show_stderr)
-        self._executable = Path('sss2')
+        super().__init__(
+            'sss2', ['{self.executable}', '{self.input_name}'],
+            template_file, extra_inputs, extra_template_inputs,
+            show_stdout, show_stderr, unit_system='cgs'
+        )
         self.input_name = "serpent_input"
-        self.unit_system = 'cgs'
-
-    @property
-    def execute_command(self):
-        return [str(self.executable), str(self.input_name)]

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -38,7 +38,10 @@ class Results:
 
     @property
     def plugin(self):
-        return type(self).__name__[7:]
+        if type(self) is Results:
+            return "Generic"
+        else:
+            return type(self).__name__[7:]
 
     @property
     def stdout(self) -> str:
@@ -95,19 +98,3 @@ class Results:
 
     def __repr__(self):
         return f"<Results{self.plugin}: {self.time}>"
-
-
-class ResultsGeneric(Results):
-    """Results from running a workflow using a generic plugin
-
-    Parameters
-    ----------
-    params
-        Parameters used to generate inputs
-    time
-        Time at which workflow was run
-    inputs
-        List of input files
-    outputs
-        List of output files
-    """

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -95,3 +95,19 @@ class Results:
 
     def __repr__(self):
         return f"<Results{self.plugin}: {self.time}>"
+
+
+class ResultsGeneric(Results):
+    """Results from running a workflow using a generic plugin
+
+    Parameters
+    ----------
+    params
+        Parameters used to generate inputs
+    time
+        Time at which workflow was run
+    inputs
+        List of input files
+    outputs
+        List of output files
+    """

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -6,24 +6,18 @@ import jinja2
 import pytest
 
 
-# Add run and postrun methods to TemplatePlugin so that it can be instantiated
-class TemplatePlugin(watts.TemplatePlugin):
-    def run(self): ...
-    def postrun(self, model): ...
-
-
 def test_undefined_template(run_in_tmpdir):
     # Create template expecting variable
     with open('example_template', 'w') as fh:
         fh.write("{{ variable }}")
 
     # Create plugin to build template
-    plugin = TemplatePlugin('example_template')
+    plugin = watts.PluginGeneric('cat', ['{self.executable}', '{self.input_name}'], 'example_template')
 
     # Passing parameters with 'variable' set should work
     params = watts.Parameters(variable=1)
     plugin.prerun(params)
-    with open('example_template.rendered', 'r') as fh:
+    with open('input_rendered', 'r') as fh:
         rendered = fh.read()
     assert rendered == '1'
 
@@ -40,12 +34,14 @@ def test_extra_template_inputs(run_in_tmpdir):
         fh.write("{{ y }}")
 
     # Create plugin to build template
-    plugin = TemplatePlugin('main_template', extra_template_inputs=['extra_template'])
+    plugin = watts.PluginGeneric(
+        'cat', ['{self.executable}', '{self.input_name}'],
+        'main_template', extra_template_inputs=['extra_template'])
 
     # Pass parameters with 'x' and 'y' set
     params = watts.Parameters(x=1, y=2)
     plugin.prerun(params)
-    with open('main_template.rendered', 'r') as fh:
+    with open('input_rendered', 'r') as fh:
         rendered = fh.read()
     assert rendered == '1'
     with open('extra_template', 'r') as fh:


### PR DESCRIPTION
This PR generalizes the `TemplatePlugin` class (now called `PluginGeneric`) such that you can use it to build a plugin for an arbitrary code by specifying the executable and command-line arguments. This changes the structure of the other classes such that they don't need to define the `execute_command` property, instead passing it directly to the `__init__` method of `PluginGeneric`.

With this new functionality, I've also expanded on our documentation to include:

- A section in the developer's guide that discusses how to build a new plugin (closes #65)
- A very simple "hello world" example in the getting started section (closes #62)

@nstauff I'd appreciate if you could test this out on the various examples (PyARC, SAM, SAS, etc.) to make sure they still function as intended.