### PR TITLE
Allow executable to be specified when creating plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changes
+
+* All plugins now support an `executable` argument to explicitly specify the
+  executable to be used ([#75](https://github.com/watts-dev/watts/pull/75))
+
 ## [0.4.0]
 
 ### Added

--- a/doc/source/user/plugins.rst
+++ b/doc/source/user/plugins.rst
@@ -31,9 +31,9 @@ If you need to specify additional input files / templates, see
 :ref:`input_files`.
 
 The MOOSE plugin defaults to using the executable ``moose-opt`` but can also be
-specified explicitly with the :attr:`~watts.PluginMOOSE.executable` attribute::
+specified explicitly ::
 
-    moose_plugin.executable = "/path/to/sam-opt"
+    moose_plugin = watts.PluginMOOSE(..., executable="/path/to/sam-opt")
 
 OpenMC Plugin
 +++++++++++++
@@ -117,10 +117,12 @@ instantiated with following command line::
 
     pyarc_plugin = watts.PluginPyARC('pyarc_template')
 
-The path to PyARC directory must be specified explicitly with the
-:attr:`~watts.PluginPyARC.executable` attribute::
+The path to the PyARC module can be specified explicitly::
 
-    pyarc_plugin.executable = "/path/to/PyARC"
+    pyarc_plugin = watts.PluginPyARC(
+        'pyarc_template',
+        executable="/path/to/PyARC/PyARC.py"
+    )
 
 To execute PyARC, the :meth:`~watts.PluginPyARC` instance is called directly the
 same way as other plugins. Extra input files and templates can be specified as
@@ -144,12 +146,10 @@ be instantiated with the following command line::
 
     sas_plugin = watts.PluginSAS('sas_template')
 
-The SAS executable is OS-dependent. It defaults to ``sas.x`` (assumed to be
-present on your :envvar:`PATH`) for Linux and macOS, and ``sas.exe`` for
-Windows. You can also explicitly specify the
-:attr:`~watts.PluginSAS.executable`::
+The name of the SAS executable is OS-dependent. It defaults to ``sas.x`` but can
+be changed if you are running on Windows::
 
-    sas_plugin.executable = "/path/to/sas-exec"
+    sas_plugin = watts.PluginSAS('sas_template', executable='sas.exe')
 
 Furthermore, the paths to the SAS utilities that convert the ".dat" files to
 ".csv" files must be specified with the :attr:`~watts.PluginSAS.conv_channel`
@@ -158,9 +158,9 @@ and :attr:`~watts.PluginSAS.conv_primar4` attributes::
     sas_plugin.conv_channel  = "/path/to/CHANNELtoCSV.x"
     sas_plugin.conv_primar4  = "/path/to/PRIMAR4toCSV.x"
 
-Similar to the SAS executable, the utilities are also OS-dependent. To execute
-SAS, the :meth:`~watts.PluginSAS` instance is called directly in the same way as
-other plugins.
+By default, the plugin will try to find these utilities based on the location of
+the SAS executable. To execute SAS, the :meth:`~watts.PluginSAS` instance is
+called directly in the same way as other plugins.
 
 RELAP5-3D Plugin
 ++++++++++++++++
@@ -219,11 +219,9 @@ MCNP Plugin
 The :class:`~watts.PluginMCNP` class handles execution of MCNP. As with other
 plugins, MCNP input files can be templated as described in
 :ref:`usage_templates`. By default, this plugin will try to call ``mcnp6`` but
-this can be changed with the :attr:`~watts.PluginMCNP.executable` attribute if
-needed::
+this can be changed if needed::
 
-    mcnp_plugin = watts.PluginMCNP('mcnp_input')
-    mcnp_plugin.executable = "mcnp5"
+    mcnp_plugin = watts.PluginMCNP('mcnp_input', executable='mcnp5')
 
 Serpent Plugin
 ++++++++++++++
@@ -309,7 +307,7 @@ Dakota with WATTS.
 To run Dakota with WATTS, the user needs to provide a number of files including
 the input file for Dakota, the WATTS Python script for executing Dakota,
 the input file for the coupled code, the WATTS script for executing the coupled
-code (note that this can involve complex workflows with several codes or iterations), 
+code (note that this can involve complex workflows with several codes or iterations),
 and the Dakota driver Python script, in addition to any file necessary to
 run the coupled code. Note that all of these files could be templated automatically
 by WATTS using the `template_file` and `extra_template_inputs` options, provided

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -166,7 +166,21 @@ Specifying an Executable
 
 Each plugin has a default executable name for the underlying code. For example,
 the :class:`~watts.PluginMCNP` class uses the executable ``mcnp6`` by default.
-You can both view and/or change the executable using the
+You can explicitly specify the path to an executable at the time a plugin is
+created::
+
+    mcnp = watts.PluginMCNP(template, executable='mcnp5')
+
+The ``executable`` argument can be given as an absolute path, in which case it
+will be used as is. Alternatively, when the ``executable`` argument is given as
+a relative path, WATTS will look for an environment variable indicating the
+directory where the executable can be found and prepend that to the executable
+if it exists. For example, the :class:`~watts.PluginMCNP` class will look for a
+:envvar:`MCNP_DIR` environment variable. If no environment variable is found,
+the directory containing the executable must be present on your :envvar:`PATH`
+environment variable.
+
+You can also view and change the executable using the
 :class:`~watts.PluginGeneric.executable` attribute:
 
 .. code-block:: pycon
@@ -174,9 +188,6 @@ You can both view and/or change the executable using the
     >>> plugin_mcnp.executable
     PosixPath('mcnp6')
     >>> plugin_mcnp.executable = 'mcnp5'
-
-If the ``executable`` you specify is not an absolute path, the directory
-containing it must be present on your :envvar:`PATH` environment variable.
 
 .. _input_files:
 

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -4,11 +4,12 @@
 from abc import ABC, abstractmethod
 from contextlib import redirect_stdout, redirect_stderr
 from datetime import datetime
-import uuid
+import os
 from pathlib import Path
 import shutil
 import time
 from typing import Optional, List, Union
+import uuid
 
 from .database import Database
 from .fileutils import cd_tmpdir, PathLike, tee_stdout, tee_stderr, run as run_proc
@@ -278,3 +279,31 @@ class PluginGeneric(Plugin):
         if extra_args is None:
             extra_args = []
         run_proc(mpi_args + self.execute_command + extra_args)
+
+
+def _find_executable(path: PathLike, environment_variable: str) -> Path:
+    """Determine executable for a given code with a hint from environment variable
+
+    Parameters
+    ----------
+    path
+        Name of exeuctable or absolute path
+    environment_variable
+        Environment variable indicating directory where executable is found
+
+    Returns
+    -------
+    Path to executable
+    """
+
+    exe = Path(path)
+
+    # If path is already an absolute path, use it
+    if exe.is_absolute():
+        return exe
+
+    # Check for environment variable
+    if (base_dir := os.environ.get(environment_variable)) is not None:
+        return base_dir / exe
+    else:
+        return exe

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -303,7 +303,5 @@ def _find_executable(path: PathLike, environment_variable: str) -> Path:
         return exe
 
     # Check for environment variable
-    if (base_dir := os.environ.get(environment_variable)) is not None:
-        return base_dir / exe
-    else:
-        return exe
+    base_dir = os.environ.get(environment_variable)
+    return base_dir / exe if base_dir is not None else exe

--- a/src/watts/plugin_abce.py
+++ b/src/watts/plugin_abce.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 
 from .fileutils import PathLike
 from .parameters import Parameters
-from .plugin import PluginGeneric
+from .plugin import PluginGeneric, _find_executable
 from .results import Results
 
 
@@ -20,6 +20,8 @@ class PluginABCE(PluginGeneric):
     ----------
     template_file
         Templated ABCE input
+    executable
+        Path to ABCE run.py script
     extra_inputs
         List of extra (non-templated) input files that are needed
     extra_template_inputs
@@ -39,14 +41,16 @@ class PluginABCE(PluginGeneric):
     """
 
 
-    def __init__(self, template_file: str,
-                 extra_inputs: Optional[List[str]] = None,
-                 extra_template_inputs: Optional[List[PathLike]] = None,
-                 show_stdout: bool = False, show_stderr: bool = False):
-        try:
-            executable = Path(os.environ['ABCE_DIR']) / 'run.py'
-        except KeyError:
-            raise OSError("Use of the ABCE plugin requires setting the ABCE_DIR environment variable.")
+    def __init__(
+        self,
+        template_file: str,
+        executable: PathLike = 'run.py',
+        extra_inputs: Optional[List[str]] = None,
+        extra_template_inputs: Optional[List[PathLike]] = None,
+        show_stdout: bool = False,
+        show_stderr: bool = False
+    ):
+        executable = _find_executable(executable, 'ABCE_DIR')
         execute_command = [sys.executable, '{self.executable}', '--settings_file', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,

--- a/src/watts/plugin_dakota.py
+++ b/src/watts/plugin_dakota.py
@@ -15,7 +15,7 @@ import subprocess
 
 from .fileutils import PathLike
 from .parameters import Parameters
-from .plugin import PluginGeneric
+from .plugin import PluginGeneric, _find_executable
 from .results import Results
 
 
@@ -88,6 +88,8 @@ class PluginDakota(PluginGeneric):
     ----------
     template_file
         Templated Dakota input
+    executable
+        Path to Dakota script
     extra_inputs
         List of extra (non-templated) input files that are needed
     extra_template_inputs
@@ -105,13 +107,17 @@ class PluginDakota(PluginGeneric):
         List of command-line arguments used to call the executable
 
     """
-    def __init__(self, template_file: str,
-                 extra_inputs: Optional[List[str]] = None,
-                 extra_template_inputs: Optional[List[PathLike]] = None,
-                 auto_link_files: Optional[str] = None,
-                 show_stdout: bool = False, show_stderr: bool = False):
-        dakota_dir = Path(os.environ.get("DAKOTA_DIR", ""))
-        executable = dakota_dir / f"dakota.sh"
+    def __init__(
+        self,
+        template_file: str,
+        executable: PathLike = 'dakota.sh',
+        extra_inputs: Optional[List[str]] = None,
+        extra_template_inputs: Optional[List[PathLike]] = None,
+        auto_link_files: Optional[str] = None,
+        show_stdout: bool = False,
+        show_stderr: bool = False
+    ):
+        executable = _find_executable(executable, 'DAKOTA_DIR')
         execute_command = ['{self.executable}', '-i', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,

--- a/src/watts/plugin_mcnp.py
+++ b/src/watts/plugin_mcnp.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from uncertainties import ufloat
 
 from .fileutils import PathLike
-from .plugin import PluginGeneric
+from .plugin import PluginGeneric, _find_executable
 from .results import Results
 
 
@@ -56,6 +56,8 @@ class PluginMCNP(PluginGeneric):
     ----------
     template_file
         Templated MCNP input
+    executable
+        Path to MCNP executable
     extra_inputs
         List of extra (non-templated) input files that are needed
     extra_template_inputs
@@ -74,12 +76,18 @@ class PluginMCNP(PluginGeneric):
 
     """
 
-    def __init__(self, template_file: str,
-                 extra_inputs: Optional[List[str]] = None,
-                 extra_template_inputs: Optional[List[PathLike]] = None,
-                 show_stdout: bool = False, show_stderr: bool = False):
+    def __init__(
+        self,
+        template_file: str,
+        executable: PathLike = 'mcnp6',
+        extra_inputs: Optional[List[str]] = None,
+        extra_template_inputs: Optional[List[PathLike]] = None,
+        show_stdout: bool = False,
+        show_stderr: bool = False
+    ):
+        executable = _find_executable(executable, 'MCNP_DIR')
         super().__init__(
-            'mcnp6', ['{self.executable}', 'i={self.input_name}'],
+            executable, ['{self.executable}', 'i={self.input_name}'],
             template_file, extra_inputs, extra_template_inputs,
             show_stdout, show_stderr, unit_system='cgs')
         self.input_name = "mcnp_input"

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from .fileutils import PathLike
 from .parameters import Parameters
-from .plugin import PluginGeneric
+from .plugin import PluginGeneric, _find_executable
 from .results import Results
 
 
@@ -103,11 +103,16 @@ class PluginMOOSE(PluginGeneric):
 
     """
 
-    def __init__(self, template_file: str,
-                 executable: PathLike = 'moose-opt',
-                 extra_inputs: Optional[List[str]] = None,
-                 extra_template_inputs: Optional[List[PathLike]] = None,
-                 show_stdout: bool = False, show_stderr: bool = False):
+    def __init__(
+        self,
+        template_file: str,
+        executable: PathLike = 'moose-opt',
+        extra_inputs: Optional[List[str]] = None,
+        extra_template_inputs: Optional[List[PathLike]] = None,
+        show_stdout: bool = False,
+        show_stderr: bool = False
+    ):
+        executable = _find_executable(executable, 'MOOSE_DIR')
         execute_command = ['{self.executable}', '-i', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,

--- a/src/watts/plugin_serpent.py
+++ b/src/watts/plugin_serpent.py
@@ -4,10 +4,8 @@
 from pathlib import Path
 from typing import List, Optional
 
-from uncertainties import ufloat
-
 from .fileutils import PathLike
-from .plugin import PluginGeneric
+from .plugin import PluginGeneric, _find_executable
 from .results import Results
 
 
@@ -41,6 +39,8 @@ class PluginSerpent(PluginGeneric):
     ----------
     template_file
         Templated Serpent input
+    executable
+        Path to Serpent executable
     extra_inputs
         List of extra (non-templated) input files that are needed
     extra_template_inputs
@@ -59,12 +59,18 @@ class PluginSerpent(PluginGeneric):
 
     """
 
-    def __init__(self, template_file: str,
-                 extra_inputs: Optional[List[str]] = None,
-                 extra_template_inputs: Optional[List[PathLike]] = None,
-                 show_stdout: bool = False, show_stderr: bool = False):
+    def __init__(
+        self,
+        template_file: str,
+        executable: PathLike = 'sss2',
+        extra_inputs: Optional[List[str]] = None,
+        extra_template_inputs: Optional[List[PathLike]] = None,
+        show_stdout: bool = False,
+        show_stderr: bool = False
+    ):
+        executable = _find_executable(executable, 'SERPENT_DIR')
         super().__init__(
-            'sss2', ['{self.executable}', '{self.input_name}'],
+            executable, ['{self.executable}', '{self.input_name}'],
             template_file, extra_inputs, extra_template_inputs,
             show_stdout, show_stderr, unit_system='cgs'
         )


### PR DESCRIPTION
This PR adds an `executable` argument to the constructor of all our plugins so that a user can specify an executable at the time the plugin is created. @nstauff ran into an issue where `PluginSerpent` was complaining that the `sss2` executable wasn't found, and the only way to fix it was to make sure that `sss2` was found via the `PATH` environment variable. With this change, one can either 1) explicitly give the absolute path of the executable or 2) give the name of the executable and specify an associated environment variable (e.g., `SERPENT_DIR`). I'll note that the way the executable is handled is now must more consistent across the different plugin classes.