### PR TITLE
Add metadata for workflows community initiative

### DIFF
--- a/.wci.yml
+++ b/.wci.yml
@@ -1,0 +1,29 @@
+---
+# Metadata parsed by the workflow community initiative, https://workflows.community/systems
+# Registered at https://github.com/workflowscommunity/workflowscommunity.github.io/blob/main/_data/workflow_systems.yml
+
+name: WATTS
+headline: Workflow and Template Toolkit for Simulation
+description: |
+  WATTS consists of a set of Python classes that can manage simulation workflows
+  for one or multiple codes. It provides: an isolated execution environment when
+  running a code; the ability to use placeholder values in input files that are
+  filled in programmatically; seamless unit conversions when working with
+  multiple codes; a managed database that simulation inputs and outputs are
+  automatically saved to; and Python classes that provide extra post-processing
+  and analysis capabilities.
+
+language: Python
+
+release:
+  version: 0.4.0
+  date: 2022-11-09
+
+documentation:
+  general: https://watts.readthedocs.io
+  installation: https://watts.readthedocs.io/en/latest/user/install.html
+  tutorial: https://watts.readthedocs.io/en/latest/user/getting_started.html
+
+execution_environment:
+  interfaces:
+    - Python API


### PR DESCRIPTION
This PR adds a .wci.yml file that contains metadata that will be used on the [Workflows Community Initiative](https://workflows.community) website (separate PR will be submitted to one of their repos adding WATTS, but that relies on this being merged first).