### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@ Fixes # (issue)
 - [ ] I have made corresponding changes to the documentation (if applicable)
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
 - [ ] I have updated the CHANGELOG.md file (if applicable)
+- [ ] I have successfully run examples that may be affected by my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Description
+
+Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.
+
+Fixes # (issue)
+
+# Checklist:
+
+- [ ] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation (if applicable)
+- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
+- [ ] I have updated the CHANGELOG.md file (if applicable)


### PR DESCRIPTION
This PR adds a [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) so that contributors will automatically see the template when making a pull request. I've added a few basic items in a checklist for the template but let me know if you can think of any others that should be included.