### PR TITLE
Simplify output in and add verbose argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * All plugins now support an `executable` argument to explicitly specify the
   executable to be used ([#75](https://github.com/watts-dev/watts/pull/75))
+* A `verbose` argument has been added to `Plugin.__call__` that controls whether
+  screen output is printed ([#82](https://github.com/watts-dev/watts/pull/82))
 
 ## [0.4.0]
 

--- a/doc/source/user/getting_started.rst
+++ b/doc/source/user/getting_started.rst
@@ -107,7 +107,19 @@ simple as changing the corresponding parameter and calling the plugin::
 
     for r in [2.0, 4.0, 6.0, 8.0, 10.0]:
         params['radius'] = r
-        result = plugin_mcnp(params)
+        result = plugin_mcnp(params, name=f'r={r}')
+
+Note that the ``name`` argument provides a means of identifying a result both
+while the code is executing as well as afterwards. During execution, the
+``name`` will be shown in the output:
+
+.. code-block:: text
+
+    [watts] Calling MCNP (r=2.0)...
+    [watts] Calling MCNP (r=4.0)...
+    [watts] Calling MCNP (r=6.0)...
+    [watts] Calling MCNP (r=8.0)...
+    [watts] Calling MCNP (r=10.0)...
 
 Results Database
 ++++++++++++++++

--- a/examples/1App_MCNP_Jezebel/watts_exec.py
+++ b/examples/1App_MCNP_Jezebel/watts_exec.py
@@ -25,13 +25,12 @@ mcnp_plugin = watts.PluginMCNP('mcnp_template')
 # 'target' argument that could specify a different target k-effective value.
 def f(radius, target=1.0):
     """Return difference between actual and target k-effective as a function of radius"""
-    print(f'Running with r={radius}...')
     # Set radius in parameters
     params['radius'] = radius
 
     # Run MCNP in parallel
     threads = str(cpu_count())
-    result = mcnp_plugin(params, extra_args=['TASKS', str(threads)])
+    result = mcnp_plugin(params, name=f'r={radius}', extra_args=['TASKS', str(threads)])
 
     # Display the resulting k-effective value
     print(f'k={result.keff}')

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -97,4 +97,8 @@ class Results:
         open_file(self.base_path)
 
     def __repr__(self):
-        return f"<Results{self.plugin}: {self.time}>"
+        if self.name:
+            return f"<Results{self.plugin}: {self.name}, {self.time})>"
+        else:
+            return f"<Results{self.plugin}: {self.time})>"
+


### PR DESCRIPTION
# Description

This PR simplifies the `print()` output from `Plugin.__call__`. Right now, a separate `print()` is done for prerun, run, and postrun, but this is not terribly useful for a user. Now, a single `print()` is done that indicates what plugin is being called and the `name` argument (if specified). I've also updated the `Results` class to include the `name` in the string representation.

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have successfully run examples that may be affected by my changes
