### PR TITLE
Store Jinja environment in TemplateRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * ACCERT plugin via the `PluginACCERT` class ([#83](https://github.com/watts-dev/watts/pull/83))
 * Command-line tool for inspecting database ([#86](https://github.com/watts-dev/watts/pull/87))
+* The `PluginMCNP` class now has an `input_file` property ([#88](https://github.com/watts-dev/watts/pull/88))
 
 ### Changes
 

--- a/src/watts/plugin_abce.py
+++ b/src/watts/plugin_abce.py
@@ -51,9 +51,8 @@ class PluginABCE(PluginGeneric):
         execute_command = [sys.executable, '{self.executable}', '--settings_file', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,
-            extra_template_inputs, show_stdout, show_stderr)
+            extra_template_inputs, 'ABCE', show_stdout, show_stderr)
         self.input_name = 'settings.yml'
-        self.plugin_name = 'ABCE'
 
 
 class ResultsABCE(Results):

--- a/src/watts/plugin_accert.py
+++ b/src/watts/plugin_accert.py
@@ -45,9 +45,8 @@ class PluginACCERT(PluginGeneric):
         executable = _find_executable(executable, 'ACCERT_DIR')
         execute_command = [sys.executable, '{self.executable}', '-i', '{self.input_name}']
         super().__init__(executable, execute_command, template_file, extra_inputs,
-                         extra_template_inputs, show_stdout, show_stderr)
+                         extra_template_inputs, "ACCERT", show_stdout, show_stderr)
         self.input_name = "ACCERT_input.son"
-        self.plugin_name = "ACCERT"
 
     @PluginGeneric.executable.setter
     def executable(self, exe: PathLike):

--- a/src/watts/plugin_dakota.py
+++ b/src/watts/plugin_dakota.py
@@ -61,7 +61,7 @@ class ResultsDakota(Results):
         if Path(dakota_out_file_name).exists():
             with open(dakota_out_file_name) as f:
                 col_names = f.readline().split()
-            df = pd.read_csv(dakota_out_file_name, sep="\s+", skiprows=1, names=col_names)
+            df = pd.read_csv(dakota_out_file_name, sep=r"\s+", skiprows=1, names=col_names)
 
             for name in col_names:
                 output_data[name] = np.array(df[name])

--- a/src/watts/plugin_dakota.py
+++ b/src/watts/plugin_dakota.py
@@ -118,10 +118,9 @@ class PluginDakota(PluginGeneric):
         execute_command = ['{self.executable}', '-i', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,
-            extra_template_inputs, show_stdout, show_stderr)
+            extra_template_inputs, "Dakota", show_stdout, show_stderr)
 
         self.input_name = template_file
-        self.plugin_name = "Dakota"
         self._auto_link_files = auto_link_files
 
         # Setup to automatically include all 'extra_inputs' and 'extra_template_inputs'

--- a/src/watts/plugin_mcnp.py
+++ b/src/watts/plugin_mcnp.py
@@ -26,11 +26,17 @@ class ResultsMCNP(Results):
 
     Attributes
     ----------
+    input_file
+        Rendered MCNP input file
     keff
         K-effective value
     stdout
         Standard output from MCNP run
     """
+
+    @property
+    def input_file(self) -> str:
+        return self.inputs[0].read_text()
 
     @property
     def keff(self) -> ufloat:

--- a/src/watts/plugin_mcnp.py
+++ b/src/watts/plugin_mcnp.py
@@ -91,7 +91,6 @@ class PluginMCNP(PluginGeneric):
         executable = _find_executable(executable, 'MCNP_DIR')
         super().__init__(
             executable, ['{self.executable}', 'i={self.input_name}'],
-            template_file, extra_inputs, extra_template_inputs,
+            template_file, extra_inputs, extra_template_inputs, "MCNP",
             show_stdout, show_stderr, unit_system='cgs')
         self.input_name = "mcnp_input"
-        self.plugin_name = "MCNP"

--- a/src/watts/plugin_moose.py
+++ b/src/watts/plugin_moose.py
@@ -113,6 +113,5 @@ class PluginMOOSE(PluginGeneric):
         execute_command = ['{self.executable}', '-i', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,
-            extra_template_inputs, show_stdout, show_stderr)
+            extra_template_inputs, "MOOSE", show_stdout, show_stderr)
         self.input_name = "MOOSE.i"
-        self.plugin_name = "MOOSE"

--- a/src/watts/plugin_pyarc.py
+++ b/src/watts/plugin_pyarc.py
@@ -73,9 +73,8 @@ class PluginPyARC(PluginGeneric):
     ):
         executable = _find_executable(executable, 'PyARC_DIR')
         super().__init__(executable, None, template_file, extra_inputs,
-                         extra_template_inputs, show_stdout, show_stderr)
+                         extra_template_inputs, "PyARC", show_stdout, show_stderr)
         self.input_name = "pyarc_input.son"
-        self.plugin_name = "PyARC"
 
     @PluginGeneric.executable.setter
     def executable(self, exe: PathLike):

--- a/src/watts/plugin_relap5.py
+++ b/src/watts/plugin_relap5.py
@@ -92,9 +92,8 @@ class PluginRELAP5(PluginGeneric):
         execute_command = ['{self.executable}', '-i', '{self.input_name}']
         super().__init__(
             executable, execute_command, template_file, extra_inputs,
-            extra_template_inputs, show_stdout, show_stderr)
+            extra_template_inputs, "RELAP5", show_stdout, show_stderr)
         self.input_name = "RELAP5.i"
-        self.plugin_name = "RELAP5"
         self.plotfl_to_csv = plotfl_to_csv
 
     def run(self, extra_args: Optional[List[str]] = None):

--- a/src/watts/plugin_sas.py
+++ b/src/watts/plugin_sas.py
@@ -106,9 +106,8 @@ class PluginSAS(PluginGeneric):
         execute_command = ['{self.executable}', '-i', '{self.input_name}',
                            '-o', 'out.txt']
         super().__init__(executable, execute_command, template_file, extra_inputs,
-                         extra_template_inputs, show_stdout, show_stderr)
+                         extra_template_inputs, "SAS", show_stdout, show_stderr)
         self.input_name = "SAS.inp"
-        self.plugin_name = "SAS"
 
         # Set other executables based on the main SAS executable
         suffix = executable.suffix

--- a/src/watts/plugin_serpent.py
+++ b/src/watts/plugin_serpent.py
@@ -68,8 +68,7 @@ class PluginSerpent(PluginGeneric):
         executable = _find_executable(executable, 'SERPENT_DIR')
         super().__init__(
             executable, ['{self.executable}', '{self.input_name}'],
-            template_file, extra_inputs, extra_template_inputs,
+            template_file, extra_inputs, extra_template_inputs, "Serpent",
             show_stdout, show_stderr, unit_system='cgs'
         )
         self.input_name = "serpent_input"
-        self.plugin_name = "Serpent"

--- a/src/watts/template.py
+++ b/src/watts/template.py
@@ -17,16 +17,28 @@ class TemplateRenderer:
     ----------
     template_file
         Path to template file
-    **template_kwargs
-        Keywork arguments passed to :class:`jinja2.Template`
+    **environment_kwargs
+        Keywork arguments passed to :class:`jinja2.Environment`
+
+    Attributes
+    ----------
+    environment : jinja2.Environment
+        Jinja environment used to manage templates
+    template_file : pathlib.Path
+        Path to template file to render
+    template : jinja2.Template
+        Template object used to render
+    suffix : str
+        Suffix added to filename when rendering a template
+
     """
-    def __init__(self, template_file: PathLike, suffix: str = '.rendered', **template_kwargs):
-        self.template_file = Path(template_file)
-        self.template = jinja2.Template(
-            self.template_file.read_text(),
+    def __init__(self, template_file: PathLike, suffix: str = '.rendered', **environment_kwargs):
+        self.environment = jinja2.Environment(
             undefined=jinja2.StrictUndefined,
-            **template_kwargs
+            **environment_kwargs
         )
+        self.template_file = Path(template_file)
+        self.template = self.environment.from_string(self.template_file.read_text())
         self.suffix = suffix
 
     def __call__(self, params: Parameters, filename: Optional[PathLike] = None):

--- a/src/watts/template.py
+++ b/src/watts/template.py
@@ -26,8 +26,6 @@ class TemplateRenderer:
         Jinja environment used to manage templates
     template_file : pathlib.Path
         Path to template file to render
-    template : jinja2.Template
-        Template object used to render
     suffix : str
         Suffix added to filename when rendering a template
 
@@ -37,8 +35,7 @@ class TemplateRenderer:
             undefined=jinja2.StrictUndefined,
             **environment_kwargs
         )
-        self.template_file = Path(template_file)
-        self.template = self.environment.from_string(self.template_file.read_text())
+        self.template_file = Path(template_file).resolve()
         self.suffix = suffix
 
     def __call__(self, params: Parameters, filename: Optional[PathLike] = None):
@@ -61,4 +58,5 @@ class TemplateRenderer:
             out_path = Path(filename)
 
         # Render template and write to file
-        out_path.write_text(self.template.render(**params))
+        template = self.environment.from_string(self.template_file.read_text())
+        out_path.write_text(template.render(**params))


### PR DESCRIPTION
# Description

This PR includes a subtle change to our `TemplateRenderer` class, which now stores a `jinja2.Environment` instance. This may be needed down the line for some envisioned features (e.g., special Jinja filters to be used for MCNP) and otherwise doesn't affect functionality.

Two other small changes:
- I added an `input_file` property to the `PluginMCNP` class
- There was a small fix needed in plugin_dakota.py that was raising a warning during tests

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] <strike>I have added tests that prove my fix is effective or that my feature works (if applicable)</strike>
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have successfully run examples that may be affected by my changes
