### PR TITLE
Add cleanup argument to Plugin.__call__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* The `Plugin.__call__` method now supports a `cleanup` argument
+  ([#92](https://github.com/watts-dev/watts/pull/92))
+
 ## [0.5.0]
 
 ### Added

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -116,6 +116,15 @@ Calling the plugin class then executes the code::
 When you call a plugin, it will return an instance of a subclass of
 :class:`~watts.Results` (see :ref:`results` for further details).
 
+Note that when a plugin is called, a temporary directory with all necessary
+files is created and used while the underlying code is running. Once the call is
+complete, the input and output files are moved to the :ref:`database
+<usage_database>` and the temporary directory is removed. To retain the
+temporary directory for debugging purposes, the ``cleanup`` argument can be
+used::
+
+    result = plugin_mcnp(cleanup=False)
+
 .. _usage_templates:
 
 Templated Inputs
@@ -304,6 +313,8 @@ results stored in `PyARC.user_object`::
     for key in pyarc_result.results_data:
         print(key, pyarc_result.results_data[key])
 
+.. _usage_database:
+
 Database
 ++++++++
 
@@ -343,7 +354,7 @@ plugins. If you want to change the default database path used in plugins, the
     >>> db.path
     PosixPath('/opt/watts_db')
 
-To remove a result from the databse, you can call the
+To remove a result from the database, you can call the
 :meth:`~watts.Database.remove` method, passing a :class:`watts.Results` object::
 
     >>> db = watts.Database()

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -6,6 +6,7 @@ import errno
 import os
 import platform
 import select
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -19,15 +20,23 @@ PathLike = Union[str, bytes, os.PathLike]
 
 
 @contextmanager
-def cd_tmpdir():
-    """Context manager to change to/return from a tmpdir."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cwd = os.getcwd()
-        try:
-            os.chdir(tmpdir)
-            yield
-        finally:
-            os.chdir(cwd)
+def cd_tmpdir(cleanup: bool = True):
+    """Context manager to change to/return from a tmpdir.
+
+    Parameters
+    ----------
+    cleanup
+        Whether to clean up the temporary directory
+    """
+    tmpdir = tempfile.mkdtemp()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmpdir)
+        yield
+    finally:
+        os.chdir(cwd)
+        if cleanup:
+            shutil.rmtree(tmpdir)
 
 
 def open_file(path: PathLike):

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -3,7 +3,6 @@
 
 from abc import ABC, abstractmethod
 from contextlib import redirect_stdout, redirect_stderr
-from datetime import datetime
 import os
 from pathlib import Path
 import shutil
@@ -68,7 +67,8 @@ class Plugin(ABC):
     def postrun(self, params: Parameters, exec_info: ExecInfo) -> Results:
         ...
 
-    def __call__(self, params: Parameters = None, name: str = '', verbose=True, **kwargs) -> Results:
+    def __call__(self, params: Parameters = None, name: str = '', verbose=True,
+                 cleanup: bool = True, **kwargs) -> Results:
         """Run the complete workflow for the plugin
 
         Parameters
@@ -79,6 +79,9 @@ class Plugin(ABC):
             Name associated with execution of plugin
         verbose
             Whether to print execution information
+        cleanup
+            Determines whether the temporary directory will be cleaned up after
+            execution.
         **kwargs
             Keyword arguments passed to the `run` method
 
@@ -102,8 +105,8 @@ class Plugin(ABC):
         timestamp = time.time_ns()
         exec_info = ExecInfo(db.job_id, plugin_name, name, timestamp)
 
-        with cd_tmpdir():
-            # Copy extra inputs to temporary directory
+        with cd_tmpdir(cleanup=cleanup):
+            # Copy extra inputs to execution directory
             cwd = Path.cwd()
             for path in self.extra_inputs:
                 shutil.copy(str(path), str(cwd))  # Remove str() for Python 3.8+

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -80,8 +80,8 @@ class Plugin(ABC):
         verbose
             Whether to print execution information
         cleanup
-            Determines whether the temporary directory will be cleaned up after
-            execution.
+            Determines whether the temporary directory will be cleaned up
+            immediately after execution.
         **kwargs
             Keyword arguments passed to the `run` method
 


### PR DESCRIPTION
# Description

This PR allows plugins to preserve the temporary directory when they are called. This can be helpful if a plugin crashes and the user wants to view the temporary directory to diagnose the issue

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have successfully run examples that may be affected by my changes
