### PR TITLE
Fix setting of executable for PluginABCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Support for natural element expansion in `PluginMCNP`
   ([#93](https://github.com/watts-dev/watts/pull/93))
 
+### Fixed
+
+* Fix setting of executable for `PluginABCE` ([#94](https://github.com/watts-dev/watts/pull/94))
+
 ## [0.5.0]
 
 ### Added

--- a/src/watts/plugin_abce.py
+++ b/src/watts/plugin_abce.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2023 UChicago Argonne, LLC
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
 import sys
 from typing import List, Optional
 
@@ -53,6 +54,16 @@ class PluginABCE(PluginGeneric):
             executable, execute_command, template_file, extra_inputs,
             extra_template_inputs, 'ABCE', show_stdout, show_stderr)
         self.input_name = 'settings.yml'
+
+    @PluginGeneric.executable.setter
+    def executable(self, exe: PathLike):
+        if not exe.is_file():
+            raise RuntimeError(
+                f"{self.plugin_name} script '{exe}' does not exist. The "
+                "ABCE_DIR environment variable needs to be set to a directory "
+                "containing the run.py script."
+            )
+        self._executable = Path(exe)
 
 
 class ResultsABCE(Results):


### PR DESCRIPTION
# Description

The `PluginABCE` class was relying on the normal `executable` property from `PluginGeneric`, which assumes the file is actually a true executable. For ABCE, it is a Python script and so we need to modify the check for the executable as is done for PyARC.

@JiaZhou-PU can you check if this resolves your issue?

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [x] I have updated the CHANGELOG.md file (if applicable)