### PR TITLE
Change PyPI release workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -21,6 +23,3 @@ jobs:
         run: python -m build
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
# Description

This PR updates the publish-pypi.yml workflow to use [trusted publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/)

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [ ] I have updated the CHANGELOG.md file (if applicable)
