### PR TITLE
Updating PluginABCE example to use new ABCE standard formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Fix setting of executable for `PluginABCE` ([#94](https://github.com/watts-dev/watts/pull/94))
+* Updated example case for `PluginABCE` ([#97](https://github.com/watts-dev/watts/pull/97))
 
 ## [0.5.0]
 

--- a/examples/1App_ABCE_C2N/abce_template.txt
+++ b/examples/1App_ABCE_C2N/abce_template.txt
@@ -1,79 +1,116 @@
-# File locations and runtime options for ABCE
-demand_data_file: "inputs/demand_data.csv"
-seed_dispatch_data_file: "inputs/ALEAF_inputs/ABCE_IL_C2N__dispatch_summary_OP__step_0.csv"
-unit_specs_abce_supp_file: "inputs/unit_specs_abce_supplemental.csv"
-retirement_period_specs_file: "inputs/portfolio_retirement_specification.csv"
-time_series_data_file: "inputs/timeseriesParams.xlsx"
-gc_params_file: "inputs/gc_params.yml"
-portfolios_file: "inputs/IL_portfolios.csv"
-db_file: {{ DATABASE_NAME }}
-ABCE_sysimage_file: "abceSysimage.so"
-dispatch_sysimage_file: "dispatch.so"
-output_file: "outputs.xlsx"
-solver: "cplex"
+simulation:
+  scenario_name: "ABCE_ERCOT_PWRC2N"
+  solver: "CPLEX"
+  num_steps: 2
+  annual_dispatch_engine: none
+  C2N_assumption: baseline
 
-first_asset_id: 2001
-
-num_steps: {{ N_STEPS }}
-
-run_ALEAF: {{ run_ALEAF }}
-
-natural_gas_price: {{ NATURAL_GAS_PRICE }}
-conv_nuclear_FOM: {{ NFOM_VALUE }}
-
-C2N_subsidy: 1  # deprecated: to remove
-C2N_assumption: baseline
-
-use_precomputed_price_curve: True # deprecated: to remove
-enable_subsidy: False # deprecated: to remove
-subsidy_amount: 0    # $/MWh
-price_cap: 9001
-
-policies:
-  CTAX:
-    enabled: False
-    qty: 30   # $/t CO2
-  PTC:
-    enabled: True
-    eligible:
-      - ConventionalNuclear
-      # - Wind
-    qty: {{ PTC_VALUE }}   # $/MWh
-num_repdays: 20
-
-allowed_xtr_types:
-  - Wind
-  - Solar
-  # - AdvancedNuclear
-  - ConventionalNuclear
-  - NGCC
-  - NGCT
-  - Coal
-
-peak_demand: 28967  # MWh, to scale load duration data
-demand_visibility_horizon: 5
-demand_projection_mode: exp_termrate     # flat, exp_fitted, or exp_termrate
-demand_projection_window: 10 # Total number of periods used to project demand
-historical_demand_growth_rate: 0.01
-terminal_demand_growth_rate: 0.01  # Exponential growth rate of demand
-planning_reserve_margin: 0.1375
-peak_initial_reserves: 0    # MW, peak reserves demand (added to PD by agent_choice.jl)
-tax_rate: 0.21
-large_epsilon: 1.0    # Value for determining non-zero-ness of large values
-num_dispatch_years: 10  # Num. of years to explicitly simulate dispatch
-
-hours_per_year: 8760
-total_forecast_horizon: 100    # Number of periods in the complete forecast horizon
-consider_future_projects: True
-num_future_periods_considered: 4    # Number of periods for which to consider future projects
-max_type_rets_per_pd: 5
-max_type_newbuilds_per_pd: 3
+scenario:
+  peak_demand: {{ peak_demand }}
+  policies:
+    CTAX:
+      enabled: True
+      qty: 0  # $/t CO2
+    PTC:
+      enabled: True
+      eligibility:
+        unit_type:
+          - conventional_nuclear
+          - wind
+          - solar
+      qty: {{ PTC_qty }}   # $/MWh
+  allowed_xtr_types:
+    - wind
+    - solar
+    - ngcc
+    - ngct
+    - PWR_C2N0_single
+    - PWR_C2N1_single
+    - HTGR_C2N0_single
+    - HTGR_C2N2_single
+    - SFR_C2N0_single
+    - SFR_C2N3_single
 
 
-#### ALEAF SETTINGS
-ALEAF_master_settings_file: "ALEAF_Master.xlsx"
-ALEAF_model_type: "LC_GEP"
-ALEAF_region: "IL"
-ALEAF_model_settings_file: "ALEAF_Master_LC_GEP.xlsx"
-ALEAF_portfolio_file: "ALEAF_IL.xlsx"
-ALEAF_scenario_name: "ABCE_IL"
+#######################################################
+#  Advanced settings
+#######################################################
+
+# Various constants: should never be updated!
+constants:
+  first_asset_id: 2001
+  vis_lvl: 45   # sets the logging level for bare visual elements
+  large_epsilon: 1.0
+  time_before_start: -1
+  distant_time: 9999
+  big_number: 999999
+  hours_per_year: 8760
+  MW2kW: 1000   # converts MW to kW
+
+# File paths and filenames
+file_paths:
+  ABCE_sysimage_file: "abceSysimage.so"
+  db_file: "abce_db.db"
+  demand_data_file: "inputs/demand_data.csv"
+  agent_specifications_file: "inputs/single_agent_testing.yml"
+#  agent_specifications_file: "inputs/agent_specifications.yml"
+  output_file: "outputs.xlsx"
+  unit_specs_data_file: "inputs/unit_specs.yml"
+  logo: "abce.txt"
+
+# Modeled grid system settings which are unlikely to change frequently
+system:
+  price_cap: 9001
+  tax_rate: 0.21
+  planning_reserve_margin: 0.1375
+  peak_initial_reserves: 0.0
+  max_total_ENS: 100000  # MWh, allowed gen. undersupply in first projected dispatch year (Energy Not Served)
+
+# Settings for demand projections
+demand:
+  total_forecast_horizon: 10   # Number of periods in the complete forecast horizon
+  demand_visibility_horizon: 2
+  demand_projection_mode: exp_termrate     # flat, exp_fitted, or exp_termrate
+  demand_projection_window: 5 # Total number of periods used to project demand
+  historical_demand_growth_rate: 0.01
+  terminal_demand_growth_rate: 0.01  # Exponential growth rate of demand
+
+# Settings for the agents' internal dispatch simulator and handling of
+#   dispatch data
+dispatch:
+  num_dispatch_years: 10  # Num. of years to explicitly simulate dispatch
+  num_repdays: 35
+  hist_wt: 0.4  # Weighting of historical versus projected data
+  hist_decay: 0.5   # Decay factor for each historical data year
+
+# Settings for agent behavior optimization
+agent_opt:
+  num_future_periods_considered: 4    # Number of periods for which to consider future projects
+  max_type_rets_per_pd: 3
+  max_type_newbuilds_per_pd: 5
+  shortage_protection_period: 8
+  cap_decrease_threshold: 1.05
+  cap_decrease_margin: -0.05
+  cap_maintain_threshold: 1.0
+  cap_maintain_margin: 0.0
+  cap_increase_margin: 0.02
+  profit_lamda: 1.0          # Note: only the ratio between the lamdas matters
+  credit_rating_lamda: 0.1
+  cr_horizon: 6
+  int_bound: 5.0
+
+financing:
+  default_debt_term: 30
+  default_equity_horizon: 30
+  depreciation_horizon: 20
+  starting_instrument_id: 1000
+
+# Filenames and settings for ALEAF
+ALEAF:
+  ALEAF_master_settings_file: "ALEAF_Master.xlsx"
+  ALEAF_model_type: "LC_GEP"
+  ALEAF_region: "ERCOT"
+  ALEAF_model_settings_file: "ALEAF_Master_LC_GEP.xlsx"
+  ALEAF_portfolio_file: "ALEAF_ERCOT.xlsx"
+  ALEAF_data_file: "inputs/ALEAF_settings.yml"
+

--- a/examples/1App_ABCE_C2N/watts_exec.py
+++ b/examples/1App_ABCE_C2N/watts_exec.py
@@ -25,8 +25,8 @@ watts.Database.set_default_path(results_path)
 params = watts.Parameters()
 
 # Set up parameter lists
-PTC_qty_list = np.linspace(start=0, stop=30, num=2) # $/MWh
-peak_demand_list = np.linspace(start=76000, stop=80000, num=2)
+PTC_qty_list = np.linspace(start=0, stop=30, num=2)  # $/MWh
+peak_demand_list = np.linspace(start=76000, stop=80000, num=2)  # MWh
 
 
 # Start the runs
@@ -40,7 +40,9 @@ for PTC_qty in PTC_qty_list:
 
         params.show_summary(show_metadata=True, sort_by="key")
 
-        abce_plugin = watts.PluginABCE(template_name, show_stdout=True, show_stderr=True)
+        abce_plugin = watts.PluginABCE(
+            template_name, show_stdout=True, show_stderr=True
+        )
 
         abce_result = abce_plugin(params, extra_args=["-f"])
 


### PR DESCRIPTION
# Description

This PR updates the ABCE-WATTS example case in `examples/1App_ABCE_C2N`. ABCE has undergone a major data format update, and the outdated ABCE input file template in the examples directory was causing the code to break. This PR updates the `PluginABCE` example input template to the new ABCE standards, and updates `watts_exec.py` to match.

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
[n/a] I have made corresponding changes to the documentation (if applicable)
[n/a] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have successfully run examples that may be affected by my changes
