### PR TITLE
Fix documentation version switcher for 0.5.0

### DIFF
--- a/doc/source/_static/switcher.json
+++ b/doc/source/_static/switcher.json
@@ -7,7 +7,7 @@
     {
         "name": "0.5.0",
         "version": "v0.5.0",
-        "url": "https://watts.readthedocs.io/en/v0.4.1/"
+        "url": "https://watts.readthedocs.io/en/v0.5.0/"
     },
     {
         "name": "0.4.0",


### PR DESCRIPTION
# Description

I just noticed that the version switcher on our documentation is broken if you try to select 0.5.0. This should fix it.