### PR TITLE
Allow individual directory names in database to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * The `Plugin.__call__` method now accepts an `output_dir` argument that
-  specifies the directory created in the database.
+  specifies the directory created in the database
+  ([#107](https://github.com/watts-dev/watts/pull/107))
 
 ## [0.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* The `Plugin.__call__` method now accepts an `output_dir` argument that
+  specifies the directory created in the database.
+
 ## [0.5.1]
 
 ### Added

--- a/doc/source/user/usage.rst
+++ b/doc/source/user/usage.rst
@@ -381,6 +381,21 @@ delete all the corresponding results on disk, including copies of the input and
 output files from the workflow stored in the data directory. Original input
 files stored outside the database directory will be unaffected.
 
+Directory names
+~~~~~~~~~~~~~~~
+
+Within the database, each result is stored in a uniquely named directory. By
+default, the directory name is generated using Python's :mod:`uuid` module.
+However, you can manually specify the directory name when a plugin is executed
+by passing the ``output_dir`` argument::
+
+    >>> result = plugin(params, output_dir='iteration_5')
+    >>> result.base_path
+    PosixPath('/home/username/.local/share/watts/iteration_5')
+
+Note that if you try to use the same ``output_dir`` twice, an exception will be
+raised.
+
 Command-line Tool
 ~~~~~~~~~~~~~~~~~
 

--- a/src/watts/plugin.py
+++ b/src/watts/plugin.py
@@ -67,8 +67,15 @@ class Plugin(ABC):
     def postrun(self, params: Parameters, exec_info: ExecInfo) -> Results:
         ...
 
-    def __call__(self, params: Parameters = None, name: str = '', verbose=True,
-                 cleanup: bool = True, **kwargs) -> Results:
+    def __call__(
+        self,
+        params: Parameters = None,
+        name: str = '',
+        output_dir: Optional[PathLike] = None,
+        verbose: bool = True,
+        cleanup: bool = True,
+        **kwargs
+    ) -> Results:
         """Run the complete workflow for the plugin
 
         Parameters
@@ -77,6 +84,9 @@ class Plugin(ABC):
             Parameters used in generating inputs
         name
             Name associated with execution of plugin
+        output_dir
+            Relative path of the directory created in the database. If None, a
+            unique directory name is created using the uuid module.
         verbose
             Whether to print execution information
         cleanup
@@ -125,7 +135,9 @@ class Plugin(ABC):
             result = self.postrun(params, exec_info)
 
             # Create new directory for results and move files there
-            workflow_path = db.path / uuid.uuid4().hex
+            if output_dir is None:
+                output_dir = uuid.uuid4().hex
+            workflow_path = db.path / output_dir
             workflow_path.mkdir()
             try:
                 result.move_files(workflow_path)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2022-2023 UChicago Argonne, LLC
+# SPDX-License-Identifier: MIT
+
+import watts
+import pytest
+
+
+def test_plugin_output_dir(run_in_tmpdir):
+    # Create templates expecting a variable
+    with open('main_template', 'w') as fh:
+        fh.write("{{ x }}")
+
+    # Create plugin to build template
+    plugin = watts.PluginGeneric(
+        'cat', ['{self.executable}', '{self.input_name}'], 'main_template')
+
+    # Pass parameters with 'x'
+    params = watts.Parameters(x=1)
+
+    # Execute plugin with specified output directory
+    res = plugin(params, output_dir='funky')
+    assert res.base_path.name == 'funky'
+
+    # Trying the same output directory again should fail
+    with pytest.raises(FileExistsError):
+        plugin(params, output_dir='funky')


### PR DESCRIPTION
# Description

Normally directory names in the database are selected at random with the `uuid` module. However, in some cases users may wish to specify the directory names. This PR adds a new `output_dir` argument on `Plugin.__call__` that enables the relative directory path to be specified.

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have successfully run examples that may be affected by my changes
