### PR TITLE
Fixed path for extra_template_inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   specifies the directory created in the database
   ([#107](https://github.com/watts-dev/watts/pull/107))
 
+### Fixed
+
+* Fixed path for templates rendered from the `extra_template_inputs` argument in
+  `PluginGeneric` and subclasses
+  ([#109](https://github.com/watts-dev/watts/pull/109))
+
 ## [0.5.1]
 
 ### Added

--- a/src/watts/template.py
+++ b/src/watts/template.py
@@ -53,7 +53,7 @@ class TemplateRenderer:
         # Default rendered template filename
         if filename is None:
             name = self.template_file.name
-            out_path = self.template_file.with_name(f'{name}{self.suffix}')
+            out_path = Path(f'{name}{self.suffix}')
         else:
             out_path = Path(filename)
 


### PR DESCRIPTION
# Description

This PR fixes the path for `extra_template_inputs`. Previously the code would overwrite the template files in the original directory instead of creating new files in the temporary directory. 

Fixes #108 

# Checklist:

- [X] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [X] I have successfully run examples that may be affected by my changes
