### PR TITLE
MPI Processes added for OpenMC Depletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Changes
-
 * Update ACCERT output name
   ([#120](https://github.com/watts-dev/watts/pull/120))
+
+### Fixed
+* Fixed `cd_tmpdir` and `move_files` to be MPI-aware, ensuring all MPI ranks
+  share the same temporary directory when running `PluginOpenMC` with
+  `integrator.integrate()` for depletion calculations
+  ([#121](https://github.com/watts-dev/watts/pull/121))
 
 ## [0.5.2]
 

--- a/examples/1App_OpenMC_Depletion/README.md
+++ b/examples/1App_OpenMC_Depletion/README.md
@@ -1,0 +1,96 @@
+# 1App_OpenMC_Depletion
+
+## Purpose
+
+This example demonstrates how to use WATTS to perform an OpenMC depletion
+calculation with MPI parallelism. It extends the `1App_OpenMC_VHTR` example
+by adding fuel depletion using `openmc.deplete.CECMIntegrator` via
+`integrator.integrate()`.
+
+This example also demonstrates the MPI-aware `cd_tmpdir` fix introduced in
+this fork, which ensures all MPI ranks share the same temporary working
+directory during depletion — resolving HDF5 file access conflicts that arise
+when running `integrator.integrate()` under `mpiexec`.
+
+## Code(s)
+
+- OpenMC
+
+## Keywords
+
+- Depletion
+- MPI parallelism
+- VHTR unit-cell model
+- CECMIntegrator
+- integrator.integrate()
+
+## Prerequisites
+
+### Cross sections
+
+Set the `OPENMC_CROSS_SECTIONS` environment variable to point to your cross
+sections library:
+
+```bash
+export OPENMC_CROSS_SECTIONS=/path/to/cross_sections.xml
+```
+
+### Depletion chain file
+
+A depletion chain file is required. Update the `chain_file` parameter in
+`watts_exec.py` to point to your local chain file:
+
+```python
+params['chain_file'] = '/path/to/chain_file.xml'
+```
+
+Chain files can be obtained from the OpenMC data repository:
+https://openmc.org/depletion-chains
+
+
+## Running the example
+
+### Serial
+
+```bash
+python watts_exec.py
+```
+
+### MPI (recommended for depletion)
+
+```bash
+mpiexec -np <N> python watts_exec.py
+```
+
+where `<N>` is the number of MPI ranks. Each rank will participate in the
+OpenMC transport calculation via `integrator.integrate()`. The Python-level
+post-processing (reading results, printing k-effective) is performed only on
+rank 0.
+
+A typical HPC submission script might look like:
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --ntasks=2
+#SBATCH --cpus-per-task=25
+
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
+export OPENMC_CROSS_SECTIONS=/path/to/cross_sections.xml
+
+mpiexec -np ${SLURM_NTASKS} python watts_exec.py
+```
+
+## File descriptions
+
+- [__watts_exec.py__](watts_exec.py): WATTS workflow for this example. This
+  is the file to execute to run the problem.
+- [__openmc_template.py__](openmc_template.py): OpenMC model builder for the
+  VHTR unit-cell geometry with depletable fuel materials.
+
+## Notes
+
+- The fuel volume set on each material is approximate — for more accurate
+  depletion, compute the exact volume of each fuel region in your geometry.
+- `integrator.integrate()` and `openmc.run()` handle MPI differently.
+  See the WATTS documentation and OpenMC depletion documentation for details.

--- a/examples/1App_OpenMC_Depletion/openmc_template.py
+++ b/examples/1App_OpenMC_Depletion/openmc_template.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2022-2025 UChicago Argonne, LLC
+# SPDX-License-Identifier: MIT
+
+from math import sqrt, pi
+
+import openmc
+import openmc.model
+
+
+def build_openmc_model(params):
+    """ OpenMC Model """
+    materials = []
+
+    # Fuel volume is required for depletion — computed from geometry below
+    fuel_pin_volume = pi * params['FuelPin_rad']**2 * (params['cl'] / 5)
+
+    homfuel1 = openmc.Material(name="homfuel_1", temperature=params['temp_F1'])
+    homfuel1.set_density('g/cm3', 2.2767E+00)
+    homfuel1.add_nuclide('U235', 4.0841E-02, 'wo')
+    homfuel1.add_nuclide('U238', 1.6597E-01, 'wo')
+    homfuel1.add_nuclide('O16',  7.0029E-01, 'wo')
+    homfuel1.add_element('C',    2.0896E-02, 'wo')
+    homfuel1.add_nuclide('Si28',  6.6155E-02, 'wo')
+    homfuel1.add_nuclide('Si29',  3.4772E-03, 'wo')
+    homfuel1.add_nuclide('Si30',  2.3671E-03, 'wo')
+    homfuel1.depletable = True
+    homfuel1.volume = fuel_pin_volume
+    materials.append(homfuel1)
+
+    homfuel2 = openmc.Material(name="homfuel_2", temperature=params['temp_F2'])
+    homfuel2.set_density('g/cm3', 2.2767E+00)
+    homfuel2.add_nuclide('U235', 4.0841E-02, 'wo')
+    homfuel2.add_nuclide('U238', 1.6597E-01, 'wo')
+    homfuel2.add_nuclide('O16',  7.0029E-01, 'wo')
+    homfuel2.add_element('C',    2.0896E-02, 'wo')
+    homfuel2.add_nuclide('Si28',  6.6155E-02, 'wo')
+    homfuel2.add_nuclide('Si29',  3.4772E-03, 'wo')
+    homfuel2.add_nuclide('Si30',  2.3671E-03, 'wo')
+    homfuel2.depletable = True
+    homfuel2.volume = fuel_pin_volume
+    materials.append(homfuel2)
+
+    homfuel3 = openmc.Material(name="homfuel_3", temperature=params['temp_F3'])
+    homfuel3.set_density('g/cm3', 2.2767E+00)
+    homfuel3.add_nuclide('U235', 4.0841E-02, 'wo')
+    homfuel3.add_nuclide('U238', 1.6597E-01, 'wo')
+    homfuel3.add_nuclide('O16',  7.0029E-01, 'wo')
+    homfuel3.add_element('C',    2.0896E-02, 'wo')
+    homfuel3.add_nuclide('Si28',  6.6155E-02, 'wo')
+    homfuel3.add_nuclide('Si29',  3.4772E-03, 'wo')
+    homfuel3.add_nuclide('Si30',  2.3671E-03, 'wo')
+    homfuel3.depletable = True
+    homfuel3.volume = fuel_pin_volume
+    materials.append(homfuel3)
+
+    homfuel4 = openmc.Material(name="homfuel_4", temperature=params['temp_F4'])
+    homfuel4.set_density('g/cm3', 2.2767E+00)
+    homfuel4.add_nuclide('U235', 4.0841E-02, 'wo')
+    homfuel4.add_nuclide('U238', 1.6597E-01, 'wo')
+    homfuel4.add_nuclide('O16',  7.0029E-01, 'wo')
+    homfuel4.add_element('C',    2.0896E-02, 'wo')
+    homfuel4.add_nuclide('Si28',  6.6155E-02, 'wo')
+    homfuel4.add_nuclide('Si29',  3.4772E-03, 'wo')
+    homfuel4.add_nuclide('Si30',  2.3671E-03, 'wo')
+    homfuel4.depletable = True
+    homfuel4.volume = fuel_pin_volume
+    materials.append(homfuel4)
+
+    homfuel5 = openmc.Material(name="homfuel_5", temperature=params['temp_F5'])
+    homfuel5.set_density('g/cm3', 2.2767E+00)
+    homfuel5.add_nuclide('U235', 4.0841E-02, 'wo')
+    homfuel5.add_nuclide('U238', 1.6597E-01, 'wo')
+    homfuel5.add_nuclide('O16',  7.0029E-01, 'wo')
+    homfuel5.add_element('C',    2.0896E-02, 'wo')
+    homfuel5.add_nuclide('Si28',  6.6155E-02, 'wo')
+    homfuel5.add_nuclide('Si29',  3.4772E-03, 'wo')
+    homfuel5.add_nuclide('Si30',  2.3671E-03, 'wo')
+    homfuel5.depletable = True
+    homfuel5.volume = fuel_pin_volume
+    materials.append(homfuel5)
+
+    boro_ctr = openmc.Material(name="B4C-CTR", temperature=params['temp'])
+    boro_ctr.set_density('g/cm3', 2.47)
+    boro_ctr.add_nuclide('B10',  0.16, 'ao')
+    boro_ctr.add_nuclide('B11',  0.64, 'ao')
+    boro_ctr.add_element('C',    0.20, 'ao')
+    materials.append(boro_ctr)
+
+    matrix = openmc.Material(name="matrix", temperature=params['temp'])
+    matrix.set_density('g/cm3', 1.806)
+    matrix.add_element('C', 1.0 - 0.0000003, 'ao')
+    matrix.add_nuclide('B10', 0.0000003, 'ao')
+    if params['use_sab']:
+        matrix.add_s_alpha_beta('c_Graphite')
+    materials.append(matrix)
+
+    refl = openmc.Material(name="BeO", temperature=params['temp'])
+    refl.set_density('g/cm3', 2.7987)
+    refl.add_nuclide('Be9', 0.50, 'ao')
+    refl.add_nuclide('O16', 0.50, 'ao')
+    if params['use_sab_BeO']:
+        refl.add_s_alpha_beta('c_Be_in_BeO')
+        refl.add_s_alpha_beta('c_O_in_BeO')
+    materials.append(refl)
+
+    yh2 = openmc.Material(name="moderator", temperature=params['temp'])
+    yh2.set_density('g/cm3', 4.30*0.95)
+    yh2.add_nuclide('Y89', 0.357142857, 'ao')
+    yh2.add_nuclide('H1',  0.642857143, 'ao')
+    if params['use_sab'] and params['use_sab_YH2']:
+        yh2.add_s_alpha_beta('c_H_in_YH2')
+        yh2.add_s_alpha_beta('c_Y_in_YH2')
+    materials.append(yh2)
+
+    coolant = openmc.Material(name="coolant", temperature=params['temp'])
+    coolant.set_density('g/cm3', 0.00365)
+    coolant.add_nuclide('He4', 1, 'ao')
+    materials.append(coolant)
+
+    Cr = openmc.Material(name="Cr", temperature=params['temp'])
+    Cr.set_density('g/cm3', 7.19)
+    Cr.add_nuclide('Cr50', 4.345e-2, 'ao')
+    Cr.add_nuclide('Cr52', 83.789e-2, 'ao')
+    Cr.add_nuclide('Cr53', 9.501e-2, 'ao')
+    Cr.add_nuclide('Cr54', 2.365e-2, 'ao')
+    materials.append(Cr)
+
+    shell_mod = openmc.Material(name="shell_mod", temperature=params['temp'])
+    shell_mod.set_density('g/cm3', 7.055)
+    shell_mod.add_nuclide('Cr50',  20.0e-2 * 4.340E-02,'ao')
+    shell_mod.add_nuclide('Cr52',  20.0e-2 * 8.381E-01,'ao')
+    shell_mod.add_nuclide('Cr53',  20.0e-2 * 9.490E-02,'ao')
+    shell_mod.add_nuclide('Cr54',  20.0e-2 * 2.360E-02,'ao')
+    shell_mod.add_nuclide('Fe54',  75.5e-2 * 5.800E-02,'ao')
+    shell_mod.add_nuclide('Fe56',  75.5e-2 * 9.172E-01,'ao')
+    shell_mod.add_nuclide('Fe57',  75.5e-2 * 2.200E-02,'ao')
+    shell_mod.add_nuclide('Fe58',  75.5e-2 * 2.800E-03,'ao')
+    shell_mod.add_nuclide('Al27',  4.5e-2  * 1.000    ,'ao')
+    materials.append(shell_mod)
+
+    materials_file = openmc.Materials(materials)
+    materials_file.export_to_xml()
+
+    Z_min = 0
+    Z_cl = params['ax_ref']
+    Z_cl_out = params['ax_ref'] - params['shell_thick']
+    Z_up = params['ax_ref'] + params['cl']
+    Z_up_out = params['ax_ref'] + params['cl'] + params['shell_thick']
+    Z_max = params['cl'] + 2 * params['ax_ref']
+
+    fuel_radius = openmc.ZCylinder(x0=0.0, y0=0.0, r=params['FuelPin_rad'])
+    mod_rad_0 = openmc.ZCylinder(x0=0.0, y0=0.0, r=params['mod_ext_rad'] - params['shell_thick'] - params['liner_thick'])
+    mod_rad_1a = openmc.ZCylinder(x0=0.0, y0=0.0, r=params['mod_ext_rad'] - params['shell_thick'])
+    mod_rad_1b = openmc.ZCylinder(x0=0.0, y0=0.0, r=params['mod_ext_rad'])
+    cool_radius = openmc.ZCylinder(x0=0.0, y0=0.0, r=params['cool_hole_rad'])
+    ctr_radius = openmc.ZCylinder(x0=0.0, y0=0.0, r=params['control_pin_rad'])
+
+    pin_pitch = params['Lattice_pitch']
+
+    min_z = openmc.ZPlane(z0=Z_min, boundary_type='vacuum')
+    max_z = openmc.ZPlane(z0=Z_max, boundary_type='vacuum')
+    sz_cl = openmc.ZPlane(z0=Z_cl)
+
+    sz_cor1 = openmc.ZPlane(z0=Z_cl + 1 * params['cl']/5)
+    sz_cor2 = openmc.ZPlane(z0=Z_cl + 2 * params['cl']/5)
+    sz_cor3 = openmc.ZPlane(z0=Z_cl + 3 * params['cl']/5)
+    sz_cor4 = openmc.ZPlane(z0=Z_cl + 4 * params['cl']/5)
+
+    sz_cl_out = openmc.ZPlane(z0=Z_cl_out)
+    sz_up = openmc.ZPlane(z0=Z_up)
+    sz_up_out = openmc.ZPlane(z0=Z_up_out)
+    cpin_low = openmc.ZPlane(z0=Z_up)
+
+    Hex_Pitch = openmc.model.hexagonal_prism(
+        orientation='x',
+        edge_length=params['Assembly_pitch']/sqrt(3),
+        origin=(0.0, 0.0),
+        boundary_type='reflective'
+    )
+
+    fuel_cell_1_1 = openmc.Cell(name='Fuel Pin', fill=homfuel1, region=-fuel_radius & +sz_cl & -sz_cor1)
+    fuel_cell_1_2 = openmc.Cell(name='Fuel Pin', fill=homfuel2, region=-fuel_radius & +sz_cor1 & -sz_cor2)
+    fuel_cell_1_3 = openmc.Cell(name='Fuel Pin', fill=homfuel3, region=-fuel_radius & +sz_cor2 & -sz_cor3)
+    fuel_cell_1_4 = openmc.Cell(name='Fuel Pin', fill=homfuel4, region=-fuel_radius & +sz_cor3 & -sz_cor4)
+    fuel_cell_1_5 = openmc.Cell(name='Fuel Pin', fill=homfuel5, region=-fuel_radius & +sz_cor4 & -sz_up)
+    fuel_cell_2 = openmc.Cell(name='matrix', fill=matrix, region=+fuel_radius & +sz_cl & -sz_up)
+    fuel_cell_3 = openmc.Cell(name='reflL', fill=refl, region=-sz_cl)
+    fuel_cell_4 = openmc.Cell(name='reflO', fill=refl, region=+sz_up)
+    fuel_universe = openmc.Universe(cells=(fuel_cell_1_1, fuel_cell_1_2, fuel_cell_1_3, fuel_cell_1_4, fuel_cell_1_5, fuel_cell_2, fuel_cell_3, fuel_cell_4))
+
+    mod_cell_1 = openmc.Cell(name='YH2', fill=yh2, region=-mod_rad_0 & +sz_cl & -sz_up)
+    mod_cell_2a = openmc.Cell(name='Liner', fill=Cr, region=+mod_rad_0 & -mod_rad_1a & +sz_cl & -sz_up)
+    mod_cell_2b = openmc.Cell(name='steel', fill=shell_mod, region=+mod_rad_1a & -mod_rad_1b & +sz_cl & -sz_up)
+    mod_cell_3 = openmc.Cell(name='matrix', fill=matrix, region=+mod_rad_1b & +sz_cl & -sz_up)
+    mod_cell_5 = openmc.Cell(name='Plug_L', fill=shell_mod, region=-mod_rad_1b & +sz_cl_out & -sz_cl)
+    mod_cell_6 = openmc.Cell(name='Plug_LR', fill=refl, region=+mod_rad_1b & +sz_cl_out & -sz_cl)
+    mod_cell_7 = openmc.Cell(name='Plug_U', fill=shell_mod, region=-mod_rad_1b & +sz_up & -sz_up_out)
+    mod_cell_8 = openmc.Cell(name='Plug_UR', fill=refl, region=+mod_rad_1b & +sz_up & -sz_up_out)
+    mod_cell_9 = openmc.Cell(name='LowRef', fill=refl, region=-sz_cl_out)
+    mod_cell_10 = openmc.Cell(name='UpRef', fill=refl, region=+sz_up)
+    mod_universe = openmc.Universe(cells=(mod_cell_1, mod_cell_2a, mod_cell_2b, mod_cell_3, mod_cell_5, mod_cell_6, mod_cell_7, mod_cell_8, mod_cell_9, mod_cell_10))
+
+    coolant_cell_1 = openmc.Cell(name='coolant', fill=coolant, region=-cool_radius)
+    coolant_cell_2 = openmc.Cell(name='matrix', fill=matrix, region=+cool_radius & +sz_cl & -sz_up)
+    coolant_cell_3 = openmc.Cell(name='reflL', fill=refl, region=+cool_radius & -sz_cl)
+    coolant_cell_4 = openmc.Cell(name='reflO', fill=refl, region=+cool_radius & +sz_up)
+    coolant_universe = openmc.Universe(cells=(coolant_cell_1, coolant_cell_2, coolant_cell_3, coolant_cell_4))
+
+    ctr_cell_1a = openmc.Cell(name='coolant', fill=coolant, region=-ctr_radius & +sz_cl & -cpin_low)
+    ctr_cell_1b = openmc.Cell(name='abs', fill=boro_ctr, region=-ctr_radius & +cpin_low)
+    ctr_cell_1c = openmc.Cell(name='refl', fill=refl, region=-ctr_radius & -sz_cl)
+    ctr_cell_2 = openmc.Cell(name='matrix', fill=matrix, region=+ctr_radius & +sz_cl & -sz_up)
+    ctr_cell_3 = openmc.Cell(name='reflL', fill=refl, region=+ctr_radius & -sz_cl)
+    ctr_cell_4 = openmc.Cell(name='reflO', fill=refl, region=+ctr_radius & +sz_up)
+    ctr_universe = openmc.Universe(cells=(ctr_cell_1a, ctr_cell_1b, ctr_cell_1c, ctr_cell_2, ctr_cell_3, ctr_cell_4))
+
+    Graph_cell_1 = openmc.Cell(name='Graph cell', fill=matrix)
+    Graph_universe = openmc.Universe(cells=(Graph_cell_1,))
+
+    assembly_description = [[]] * 6
+    assembly_description[5] = ([ctr_universe])
+    assembly_description[4] = ([fuel_universe]) * 6
+    assembly_description[3] = ([fuel_universe] + [coolant_universe]) * 6
+    assembly_description[2] = ([coolant_universe] + [fuel_universe] + [mod_universe] + [coolant_universe] + [fuel_universe] + [mod_universe]) * 3
+    assembly_description[1] = ([fuel_universe] + [fuel_universe] + [coolant_universe] + [fuel_universe]) * 6
+    assembly_description[0] = ([fuel_universe] + [coolant_universe] + [fuel_universe] + [fuel_universe] + [coolant_universe]) * 6
+
+    lat_core = openmc.HexLattice()
+    lat_core.center = (0, 0)
+    lat_core.pitch = [pin_pitch]
+    lat_core.outer = Graph_universe
+    lat_core.universes = assembly_description
+
+    rotated_lat_core = openmc.Cell(fill=lat_core)
+    rotated_universe_lat_core = openmc.Universe(cells=(rotated_lat_core,))
+    new_cell_lat_core = openmc.Cell()
+    new_cell_lat_core.fill = rotated_universe_lat_core
+    new_cell_lat_core.rotation = (0., 0., 90.)
+    new_universe_lat_core = openmc.Universe(cells=(new_cell_lat_core,))
+
+    main_cell = openmc.Cell(name="MainCell", fill=new_universe_lat_core, region=Hex_Pitch & +min_z & -max_z)
+    root_universe = openmc.Universe(name='root universe', cells=(main_cell,))
+
+    geometry = openmc.Geometry()
+    geometry.root_universe = root_universe
+    geometry.export_to_xml()
+
+    settings_file = openmc.Settings()
+    settings_file.run_mode = 'eigenvalue'
+    settings_file.batches = params['batches']
+    settings_file.inactive = params['inactive']
+    settings_file.particles = params['particles']
+    settings_file.statepoint = {'batches': []}  # disable statepoint writing for MPI compatibility
+    settings_file.material_cell_offsets = False
+    settings_file.temperature = {'method': 'interpolation'}
+
+    source = openmc.IndependentSource()
+    ll = [-params['Assembly_pitch']/4, -params['Assembly_pitch']/4, Z_min]
+    ur = [params['Assembly_pitch']/4,  params['Assembly_pitch']/4, Z_max]
+    source.space = openmc.stats.Box(ll, ur)
+    source.strength = 1.0
+    settings_file.source = source
+    settings_file.export_to_xml()

--- a/examples/1App_OpenMC_Depletion/watts_exec.py
+++ b/examples/1App_OpenMC_Depletion/watts_exec.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2022-2025 UChicago Argonne, LLC
+# SPDX-License-Identifier: MIT
+
+"""
+This example demonstrates how to use WATTS to perform an OpenMC depletion
+calculation using integrator.integrate() with MPI parallelism. The VHTR
+unit-cell model from the 1App_OpenMC_VHTR example is reused here with
+depletable fuel materials.
+
+When running with MPI, all ranks share the same temporary working directory
+via the MPI-aware cd_tmpdir fix, ensuring coordinated HDF5 file I/O during
+depletion.
+
+Run in serial:
+    python watts_exec.py
+
+Run with MPI (recommended for depletion):
+    mpiexec -np <N> python watts_exec.py
+"""
+
+from math import cos, pi
+
+import openmc
+import openmc.deplete
+import watts
+from astropy.units import Quantity
+
+from openmc_template import build_openmc_model
+
+
+params = watts.Parameters()
+
+# Core design params
+params['ax_ref'] = 20                                               # cm
+params['num_cool_pins'] = 1*6 + 2*6 + 6*2/2
+params['num_fuel_pins'] = 6 + 6 + 6 + 3*6 + 2*6/2 + 6/3
+params['Height_FC'] = 2.0                                           # m
+params['Lattice_pitch'] = 2.0
+params['FuelPin_rad'] = 0.90                                        # cm
+params['cool_hole_rad'] = 0.60                                      # cm
+params['Coolant_channel_diam'] = (params['cool_hole_rad'] * 2)/100 # m
+params['Graphite_thickness'] = (params['Lattice_pitch'] - params['FuelPin_rad'] - params['cool_hole_rad'])  # cm
+params['Assembly_pitch'] = 7.5 * 2 * params['Lattice_pitch'] / (cos(pi/6) * 2)
+params['lbp_rad'] = 0.25                                            # cm
+params['mod_ext_rad'] = 0.90                                        # cm
+params['shell_thick'] = 0.05                                        # FeCrAl
+params['liner_thick'] = 0.007                                       # Cr
+params['control_pin_rad'] = Quantity(9.9, "mm")
+
+# Control use of S(a,b) tables
+params['use_sab'] = True
+params['use_sab_BeO'] = True
+params['use_sab_YH2'] = False
+
+# OpenMC transport params
+params['cl'] = params['Height_FC'] * 100 - 2 * params['ax_ref']    # cm
+params['pf'] = 40                                                   # percent
+params['batches'] = 100
+params['inactive'] = 30
+params['particles'] = 1000
+
+# Temperature params
+params['temp'] = Quantity(725, "Celsius")
+for i in range(1, 6):
+    params[f'temp_F{i}'] = Quantity(725, "Celsius")
+
+# Depletion params — time steps in days
+params['time_steps'] = [10, 20]              # days
+params['power'] = 1e6                                               # W (1 MWt)
+
+# Path to depletion chain file — adjust to match your local installation
+# See: https://openmc.org/depletion-chains for available chain files
+params['chain_file'] = '/home/garcsamu/OpenMC/TEMA/data/chain_casl_pwr.xml'
+
+params.show_summary(show_metadata=False, sort_by='time')
+
+
+def run_depletion(params):
+    """Run OpenMC depletion using CECMIntegrator.
+
+    All MPI ranks participate in transport via integrator.integrate().
+    Post-processing of results is performed only on rank 0.
+
+    Parameters
+    ----------
+    params
+        WATTS parameters dictionary
+    """
+    # Load geometry and settings written by build_openmc_model
+    geometry = openmc.Geometry.from_xml()
+    settings = openmc.Settings.from_xml()
+
+    # Set up depletion operator using the coupled transport approach
+    operator = openmc.deplete.CoupledOperator(
+        openmc.Model(geometry=geometry, settings=settings),
+        chain_file=params['chain_file']
+    )
+
+    # Set up time steps and power list for CECMIntegrator
+    power_list = [params['power']] * len(params['time_steps'])
+    integrator = openmc.deplete.CECMIntegrator(
+        operator, params['time_steps'], power_list, timestep_units='d'
+    )
+
+    print("Starting depletion...")
+    integrator.integrate()
+    print("Depletion complete.")
+
+    # Post-process results — only rank 0 reads output files
+    try:
+        from mpi4py import MPI
+        rank = MPI.COMM_WORLD.Get_rank()
+    except ImportError:
+        rank = 0
+
+    if rank == 0:
+        results = openmc.deplete.Results('depletion_results.h5')
+        time, keff = results.get_keff()
+        time_days = [t / 86400 for t in time]
+
+        # Store final k-effective in params
+        params['keff_final'] = float(keff[-1][0])
+        params['time_days'] = time_days
+
+
+# Create OpenMC plugin and run depletion
+openmc_plugin = watts.PluginOpenMC(build_openmc_model, show_stderr=True, show_stdout=True)
+openmc_plugin(params, function=lambda: run_depletion(params))
+
+params.show_summary(show_metadata=False, sort_by='time')

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -131,13 +131,17 @@ def run(args):
     Based on https://stackoverflow.com/a/12272262 and
     https://stackoverflow.com/a/7730201
     """
+    # Windows doesn't support select.select and fcntl module so just default to
+    # using subprocess.run. In this case, show_stdout/show_stderr won't work.
     if sys.platform == 'win32':
         subprocess.run(args)
         return
 
+    # Helper function to add the O_NONBLOCK flag to a file descriptor
     def make_async(fd):
         fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
 
+    # Helper function to read some data from a file descriptor, ignoring EAGAIN errors
     def read_async(fd):
         try:
             return fd.read()

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from typing import Union
 
 if sys.platform != 'win32':
@@ -30,6 +31,11 @@ def cd_tmpdir(cleanup: bool = True):
     ----------
     cleanup
         Whether to clean up the temporary directory
+
+    Yields
+    ------
+    None
+        Yields control to the caller while in the temporary directory
     """
     try:
         from mpi4py import MPI
@@ -38,19 +44,19 @@ def cd_tmpdir(cleanup: bool = True):
 
         # Only rank 0 creates the tmp directory
         if rank == 0:
-            tmpdir = tempfile.mkdtemp()
+            tmpdir = Path(tempfile.mkdtemp())
         else:
             tmpdir = None
 
         # Broadcast the path to all ranks so they share the same directory
-        tmpdir = comm.bcast(tmpdir, root=0)
+        tmpdir = Path(comm.bcast(str(tmpdir) if tmpdir else None, root=0))
 
     except ImportError:
         # mpi4py not available, fall back to normal serial behavior
-        tmpdir = tempfile.mkdtemp()
+        tmpdir = Path(tempfile.mkdtemp())
         rank = 0
 
-    cwd = os.getcwd()
+    cwd = Path.cwd()
     try:
         os.chdir(tmpdir)
         yield

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -66,6 +66,7 @@ def cd_tmpdir(cleanup: bool = True):
             try:
                 from mpi4py import MPI
                 # Only rank 0 cleans up to avoid race conditions
+                MPI.COMM_WORLD.Barrier()    
                 if MPI.COMM_WORLD.Get_rank() == 0:
                     shutil.rmtree(tmpdir)
             except ImportError:

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -23,12 +23,33 @@ PathLike = Union[str, bytes, os.PathLike]
 def cd_tmpdir(cleanup: bool = True):
     """Context manager to change to/return from a tmpdir.
 
+    If running under MPI, all ranks will share the same temporary directory
+    to allow coordinated file I/O (e.g. HDF5 statepoint writing in OpenMC).
+
     Parameters
     ----------
     cleanup
         Whether to clean up the temporary directory
     """
-    tmpdir = tempfile.mkdtemp()
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+
+        # Only rank 0 creates the tmp directory
+        if rank == 0:
+            tmpdir = tempfile.mkdtemp()
+        else:
+            tmpdir = None
+
+        # Broadcast the path to all ranks so they share the same directory
+        tmpdir = comm.bcast(tmpdir, root=0)
+
+    except ImportError:
+        # mpi4py not available, fall back to normal serial behavior
+        tmpdir = tempfile.mkdtemp()
+        rank = 0
+
     cwd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -36,7 +57,13 @@ def cd_tmpdir(cleanup: bool = True):
     finally:
         os.chdir(cwd)
         if cleanup:
-            shutil.rmtree(tmpdir)
+            try:
+                from mpi4py import MPI
+                # Only rank 0 cleans up to avoid race conditions
+                if MPI.COMM_WORLD.Get_rank() == 0:
+                    shutil.rmtree(tmpdir)
+            except ImportError:
+                shutil.rmtree(tmpdir)
 
 
 def open_file(path: PathLike):
@@ -104,17 +131,13 @@ def run(args):
     Based on https://stackoverflow.com/a/12272262 and
     https://stackoverflow.com/a/7730201
     """
-    # Windows doesn't support select.select and fcntl module so just default to
-    # using subprocess.run. In this case, show_stdout/show_stderr won't work.
     if sys.platform == 'win32':
         subprocess.run(args)
         return
 
-    # Helper function to add the O_NONBLOCK flag to a file descriptor
     def make_async(fd):
         fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
 
-    # Helper function to read some data from a file descriptor, ignoring EAGAIN errors
     def read_async(fd):
         try:
             return fd.read()

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -100,12 +100,12 @@ class Results:
         # Only rank 0 moves files to avoid race conditions when all ranks
         # share the same tmp directory (MPI-aware cd_tmpdir)
         if rank == 0:
-            for i, input in enumerate(self.inputs):
-                shutil.move(str(input), str(dst_path / input.name))
-                self.inputs[i] = dst_path / input.name
-            for i, output in enumerate(self.outputs):
-                shutil.move(str(output), str(dst_path / output.name))
-                self.outputs[i] = dst_path / output.name
+            for i, inp in enumerate(self.inputs):
+                shutil.move(inp, dst_path / inp.name)
+                self.inputs[i] = dst_path / inp.name
+            for i, out in enumerate(self.outputs):
+                shutil.move(out, dst_path / out.name)
+                self.outputs[i] = dst_path / out.name
             self.base_path = dst_path
 
         # All ranks wait until rank 0 finishes moving files
@@ -117,10 +117,10 @@ class Results:
 
         # Non-rank-0 processes need to update their paths too
         if rank != 0:
-            for i, input in enumerate(self.inputs):
-                self.inputs[i] = dst_path / input.name
-            for i, output in enumerate(self.outputs):
-                self.outputs[i] = dst_path / output.name
+            for i, inp in enumerate(self.inputs):
+                self.inputs[i] = dst_path / inp.name
+            for i, out in enumerate(self.outputs):
+                self.outputs[i] = dst_path / out.name
             self.base_path = dst_path
 
     def save(self, filename: PathLike):

--- a/src/watts/results.py
+++ b/src/watts/results.py
@@ -88,18 +88,40 @@ class Results:
             Destination path where files should be moved
 
         """
+        try:
+            from mpi4py import MPI
+            comm = MPI.COMM_WORLD
+            rank = comm.Get_rank()
+        except ImportError:
+            rank = 0
 
         dst_path = Path(dst)
-        # Move input/output files and change base -- note that trying to use the
-        # Path.replace method doesn't work across filesystems, so instead we use
-        # shutil.move
-        for i, input in enumerate(self.inputs):
-            shutil.move(str(input), str(dst_path / input.name))
-            self.inputs[i] = dst_path / input.name
-        for i, output in enumerate(self.outputs):
-            shutil.move(str(output), str(dst_path / output.name))
-            self.outputs[i] = dst_path / output.name
-        self.base_path = dst_path
+
+        # Only rank 0 moves files to avoid race conditions when all ranks
+        # share the same tmp directory (MPI-aware cd_tmpdir)
+        if rank == 0:
+            for i, input in enumerate(self.inputs):
+                shutil.move(str(input), str(dst_path / input.name))
+                self.inputs[i] = dst_path / input.name
+            for i, output in enumerate(self.outputs):
+                shutil.move(str(output), str(dst_path / output.name))
+                self.outputs[i] = dst_path / output.name
+            self.base_path = dst_path
+
+        # All ranks wait until rank 0 finishes moving files
+        try:
+            from mpi4py import MPI
+            MPI.COMM_WORLD.Barrier()
+        except ImportError:
+            pass
+
+        # Non-rank-0 processes need to update their paths too
+        if rank != 0:
+            for i, input in enumerate(self.inputs):
+                self.inputs[i] = dst_path / input.name
+            for i, output in enumerate(self.outputs):
+                self.outputs[i] = dst_path / output.name
+            self.base_path = dst_path
 
     def save(self, filename: PathLike):
         """Save results to a pickle file

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -4,6 +4,7 @@
 from contextlib import redirect_stdout
 import io
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import os
@@ -57,24 +58,24 @@ def test_run(run_in_tmpdir):
 
 # Last two tests make sure that cd_tmpdir functions after mpi changes for serial runs
 def test_cd_tmpdir(run_in_tmpdir):
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     with cd_tmpdir():
-        tmp_cwd = os.getcwd()
+        tmp_cwd = Path.cwd()
         # Should have changed to a different directory
         assert tmp_cwd != original_cwd
         # Should be a real writable directory
         Path('test_file.txt').touch()
         assert Path('test_file.txt').exists()
     # Should return to original directory after context manager exits
-    assert os.getcwd() == original_cwd
+    assert Path.cwd() == original_cwd
     # Tmp dir should be cleaned up by default
-    assert not Path(tmp_cwd).exists()
+    assert not tmp_cwd.exists()
+
 
 def test_cd_tmpdir_no_cleanup(run_in_tmpdir):
     with cd_tmpdir(cleanup=False):
-        tmp_cwd = os.getcwd()
+        tmp_cwd = Path.cwd()
     # Tmp dir should still exist when cleanup=False
-    assert Path(tmp_cwd).exists()
+    assert tmp_cwd.exists()
     # Clean up manually
-    import shutil
     shutil.rmtree(tmp_cwd)

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -6,8 +6,8 @@ import io
 from pathlib import Path
 import subprocess
 import sys
-
-from watts.fileutils import tee_stdout, tee_stderr, run
+import os
+from watts.fileutils import tee_stdout, tee_stderr, run, cd_tmpdir
 
 
 def test_tee_stdout(run_in_tmpdir, capsys):
@@ -55,3 +55,26 @@ def test_run(run_in_tmpdir):
         run(['env'])
     assert f.getvalue() == file_output
 
+# Last two tests make sure that cd_tmpdir functions after mpi changes for serial runs
+def test_cd_tmpdir(run_in_tmpdir):
+    original_cwd = os.getcwd()
+    with cd_tmpdir():
+        tmp_cwd = os.getcwd()
+        # Should have changed to a different directory
+        assert tmp_cwd != original_cwd
+        # Should be a real writable directory
+        Path('test_file.txt').touch()
+        assert Path('test_file.txt').exists()
+    # Should return to original directory after context manager exits
+    assert os.getcwd() == original_cwd
+    # Tmp dir should be cleaned up by default
+    assert not Path(tmp_cwd).exists()
+
+def test_cd_tmpdir_no_cleanup(run_in_tmpdir):
+    with cd_tmpdir(cleanup=False):
+        tmp_cwd = os.getcwd()
+    # Tmp dir should still exist when cleanup=False
+    assert Path(tmp_cwd).exists()
+    # Clean up manually
+    import shutil
+    shutil.rmtree(tmp_cwd)

--- a/tests/test_mpi_tmpdir.py
+++ b/tests/test_mpi_tmpdir.py
@@ -1,22 +1,23 @@
 from mpi4py import MPI
 from watts.fileutils import cd_tmpdir
-import os
+from pathlib import Path
 # checking to make sure each tmpdir only created with rank 0
 # to run test run standalone script with 
 # mpiexec -np 2 python test_mpi_tmpdir.py
 
-green = '\033[92m'
-red =  '\033[91m'
-reset = '\033[0m'
+green = "\033[92m"
+red = "\033[91m"
+reset = "\033[0m"
+
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
 
 with cd_tmpdir():
-    tmpdir = os.getcwd()
+    tmpdir = Path.cwd()
 
     # Gather all ranks' directories to rank 0
-    all_dirs = comm.gather(tmpdir, root=0)
+    all_dirs = comm.gather(str(tmpdir), root=0)
 
     if rank == 0:
         print(f"\nRunning MPI tmp directory test with {size} ranks")
@@ -25,7 +26,6 @@ with cd_tmpdir():
             print(f"  Rank {i}: {d}")
         print(f"{'─' * 50}")
 
-        # Check all directories are the same
         unique_dirs = set(all_dirs)
         if len(unique_dirs) == 1:
             print(f"{green}PASSED: All {size} ranks share the same tmp directory{reset}\n")
@@ -34,9 +34,9 @@ with cd_tmpdir():
             print(f"{red}Expected 1 unique directory, got {len(unique_dirs)}{reset}\n")
             raise AssertionError("MPI ranks do not share the same tmp directory")
 
-# verify cleanup of tmpdir 
+# After context manager — verify cleanup on rank 0
 if rank == 0:
-    if not os.path.exists(tmpdir):
+    if not tmpdir.exists():
         print(f"{green}PASSED: Tmp directory was cleaned up correctly{reset}\n")
     else:
         print(f"{red}FAILED: Tmp directory was not cleaned up{reset}\n")

--- a/tests/test_mpi_tmpdir.py
+++ b/tests/test_mpi_tmpdir.py
@@ -1,0 +1,43 @@
+from mpi4py import MPI
+from watts.fileutils import cd_tmpdir
+import os
+# checking to make sure each tmpdir only created with rank 0
+# to run test run standalone script with 
+# mpiexec -np 2 python test_mpi_tmpdir.py
+
+green = '\033[92m'
+red =  '\033[91m'
+reset = '\033[0m'
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+with cd_tmpdir():
+    tmpdir = os.getcwd()
+
+    # Gather all ranks' directories to rank 0
+    all_dirs = comm.gather(tmpdir, root=0)
+
+    if rank == 0:
+        print(f"\nRunning MPI tmp directory test with {size} ranks")
+        print(f"{'─' * 50}")
+        for i, d in enumerate(all_dirs):
+            print(f"  Rank {i}: {d}")
+        print(f"{'─' * 50}")
+
+        # Check all directories are the same
+        unique_dirs = set(all_dirs)
+        if len(unique_dirs) == 1:
+            print(f"{green}PASSED: All {size} ranks share the same tmp directory{reset}\n")
+        else:
+            print(f"{red}FAILED: Ranks have different tmp directories!{reset}")
+            print(f"{red}Expected 1 unique directory, got {len(unique_dirs)}{reset}\n")
+            raise AssertionError("MPI ranks do not share the same tmp directory")
+
+# verify cleanup of tmpdir 
+if rank == 0:
+    if not os.path.exists(tmpdir):
+        print(f"{green}PASSED: Tmp directory was cleaned up correctly{reset}\n")
+    else:
+        print(f"{red}FAILED: Tmp directory was not cleaned up{reset}\n")
+        raise AssertionError("Tmp directory was not cleaned up after context manager exit")

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -291,3 +291,33 @@ prop1  prop2
     assert new_results.inputs == results.inputs
     assert new_results.outputs == results.outputs
     assert new_results.stdout == results.stdout
+
+def test_move_files(run_in_tmpdir):
+    # testing move files works properly after mpi changes
+    params = watts.Parameters(city='Chicago', population=2.7e6)
+    timestamp = time.time_ns()
+    exec_info = watts.ExecInfo(123, 'OpenMC', 'test', timestamp)
+
+    # Create some fake input and output files
+    geom_xml = Path('geometry.xml')
+    geom_xml.touch()
+    sp = Path('statepoint.50.h5')
+    sp.touch()
+    log_file = Path('OpenMC_log.txt')
+    log_file.write_text("output\n")
+
+    results = watts.ResultsOpenMC(params, exec_info, [geom_xml], [sp, log_file])
+
+    # Move fake files to a new location
+    dst = Path('new_location')
+    dst.mkdir()
+    results.move_files(dst)
+
+    # check that files are in new destination
+    assert (dst / 'geometry.xml').exists()
+    assert (dst / 'statepoint.50.h5').exists()
+    assert (dst / 'OpenMC_log.txt').exists()
+
+    # Check that path in results object are updated 
+    assert results.inputs[0] == dst / 'geometry.xml'
+    assert results.base_path == dst


### PR DESCRIPTION
# Description

This PR updates functionality in `src/watts/fileutils.py` and `src/watts/results.py` to allow for more than one mpi processes to be utilized in openmc calculations which are most relevant for depletion. Previously launching more than one mpi process would 1) open separate tmp directories per rank leading to permissions issues when reading statepoint files and 2) would lead to race issues when cleaning up context manager. This PR updates `cd_tmpdir()` and `move_files()` to force all ranks to run in the same tmp directory and to only allow for one rank to move files after calculation is complete. Example of MPI usage with WATTS is shown in `examples/1App_OpenMC_Depletion` using example VHTR model. New tests for serial and mpi usage of `cd_tmpdir` and `move_files` is also implemented and checked.

Fixes #122 

# Checklist:

- [x] My code follows the [style guidelines](https://watts.readthedocs.io/en/latest/dev/styleguide.html)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have successfully run examples that may be affected by my changes
