### PR TITLE
fix(fileutils): drain pipe buffers after process exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Update ACCERT output name
   ([#120](https://github.com/watts-dev/watts/pull/120))
 
+### Fixed
+
+* Capture output remaining in subprocess pipe buffers after the process exits
+  ([#124](https://github.com/watts-dev/watts/pull/124))
+
 ## [0.5.2]
 
 ### Added

--- a/src/watts/fileutils.py
+++ b/src/watts/fileutils.py
@@ -140,3 +140,15 @@ def run(args):
 
         if p.poll() is not None:
             break
+
+    # Drain any data remaining in the pipe buffers after the process exits.
+    # With O_NONBLOCK, a single read() per iteration may not consume all buffered
+    # bytes (the kernel returns what fits in one syscall). Once the write end of
+    # the pipe is closed (process exited) read_async returns b'' on EOF rather
+    # than raising EAGAIN, so this loop terminates cleanly.
+    for fd, stream in ((p.stdout, sys.stdout), (p.stderr, sys.stderr)):
+        while True:
+            chunk = read_async(fd)
+            if not chunk:
+                break
+            stream.write(chunk.decode())

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
 from watts.fileutils import tee_stdout, tee_stderr, run
 
 
@@ -54,4 +56,24 @@ def test_run(run_in_tmpdir):
     with redirect_stdout(io.StringIO()) as f:
         run(['env'])
     assert f.getvalue() == file_output
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="O_NONBLOCK not available on Windows")
+def test_run_captures_all_output(run_in_tmpdir):
+    # Emit enough output to fill multiple pipe-buffer reads (typically 64 KB),
+    # then verify every byte is captured.  This is a regression test for the
+    # post-exit drain: without draining after p.poll() returns, the last chunk
+    # of buffered data could be silently dropped.
+    line = "x" * 79 + "\n"   # 80 bytes per line
+    n_lines = 2000            # 160 000 bytes — well past one pipe-buffer read
+    script = f"import sys; [sys.stdout.write({line!r}) for _ in range({n_lines})]"
+
+    with redirect_stdout(io.StringIO()) as f:
+        run([sys.executable, '-c', script])
+
+    captured = f.getvalue()
+    assert captured == line * n_lines, (
+        f"Expected {n_lines * 80} bytes but got {len(captured)}; "
+        "output was likely truncated due to missing post-exit drain"
+    )
 


### PR DESCRIPTION
## Problem

`fileutils.run()` uses `O_NONBLOCK` + `read_async()` to avoid the classic pipe deadlock (write-end full while parent blocks reading the wrong fd). However, when the subprocess exits `run()` breaks out of the read loop as soon as `p.poll()` returns non-`None` — potentially before all data the process wrote has been drained from the kernel pipe buffer.

With `O_NONBLOCK` a single `read()` syscall returns only what the kernel has ready at that instant; a large burst of output written just before process exit (common in nuclear simulation and optimization codes) can silently disappear. This is the underlying cause of the hang/truncation behaviour reported in #49.

## Fix

Add a post-exit drain loop for both `stdout` and `stderr` (2 + the `while True` loop in `fileutils.py`). Once the write end of the pipe is closed, `read_async()` returns `b""` (EOF) rather than `EAGAIN`, so the loop terminates immediately after all buffered bytes are consumed.

## Test

Added `test_run_captures_all_output` which emits **160 000 bytes** of output — well past a typical 64 KB pipe-buffer read — and asserts every byte is captured. The test is `skipif win32` (same as the rest of the non-blocking path).

```
tests/test_fileutils.py::test_run_captures_all_output PASSED
```

All 4 `test_fileutils` tests pass.

Fixes #49

---
Signed-off-by: Mike German <mike@stepsventures.com>